### PR TITLE
Feat[MD-69]: Implementation of IDs in the logs of every request/petition

### DIFF
--- a/backend/src/modules/repository_documents/documents.module.ts
+++ b/backend/src/modules/repository_documents/documents.module.ts
@@ -47,12 +47,17 @@ import { GenerateDocumentEmbeddingsUseCase } from './application/use-cases/gener
 import { SearchDocumentsUseCase } from './application/use-cases/search-documents.use-case';
 import { NestModule, MiddlewareConsumer, RequestMethod } from '@nestjs/common';
 import { AuthMiddleware } from './infrastructure/http/middleware/auth.middleware';
+import { LoggingMiddleware } from './infrastructure/http/middleware/logging.middleware';
+import { ContextualLoggerService } from './infrastructure/services/contextual-logger.service';
 @Module({
   imports: [PrismaModule, IdentityModule],
   controllers: [DocumentsController, EmbeddingsController],
   providers: [
     // Servicios de configuración
     AiConfigService,
+
+    // Servicios de logging
+    ContextualLoggerService,
 
     // Infrastructure adapters
     { provide: DOCUMENT_STORAGE_PORT, useClass: S3StorageAdapter },
@@ -238,7 +243,7 @@ import { AuthMiddleware } from './infrastructure/http/middleware/auth.middleware
 export class DocumentsModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(AuthMiddleware)
-      .forRoutes({ path: 'api/documents/upload', method: RequestMethod.POST });
+      .apply(LoggingMiddleware)
+      .forRoutes('api/documents', 'api/repository-documents/embeddings');
   }
 }

--- a/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts
@@ -16,6 +16,7 @@ import {
 import { Request } from 'express';
 import type { AuthenticatedRequest } from '../http/middleware/auth.middleware';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ContextualLoggerService } from '../services/contextual-logger.service';
 import { ListDocumentsUseCase } from '../../application/queries/list-documents.usecase';
 import { DeleteDocumentUseCase } from '../../application/commands/delete-document.usecase';
 import { UploadDocumentUseCase } from '../../application/commands/upload-document.usecase';
@@ -32,8 +33,6 @@ import {
 import type { UploadDocumentResponseDto } from '../http/dtos/upload-document.dto';
 import { DownloadDocumentUseCase } from '../../application/commands/download-document.usecase';
 
-// ⬅️ Remover esta interface, ahora viene del middleware
-// interface AuthenticatedRequest extends Request {
 @Controller('api/documents')
 export class DocumentsController {
   constructor(
@@ -43,11 +42,14 @@ export class DocumentsController {
     private readonly downloadDocumentUseCase: DownloadDocumentUseCase,
     private readonly processDocumentTextUseCase: ProcessDocumentTextUseCase,
     private readonly processDocumentChunksUseCase: ProcessDocumentChunksUseCase,
+    private readonly logger: ContextualLoggerService,
   ) {}
 
   @Get()
   async listDocuments(): Promise<DocumentListResponseDto> {
     try {
+      this.logger.logDocumentOperation('list');
+      
       const result = await this.listDocumentsUseCase.execute();
 
       // Mapear la respuesta del dominio a DTOs
@@ -64,6 +66,11 @@ export class DocumentsController {
           ),
       );
 
+      this.logger.log('Documents retrieved successfully', {
+        totalDocuments: result.total,
+        documentsReturned: documents.length,
+      });
+
       return new DocumentListResponseDto(
         documents,
         result.total,
@@ -72,6 +79,10 @@ export class DocumentsController {
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
+
+      this.logger.error('Error retrieving documents', error instanceof Error ? error : errorMessage, {
+        errorType: 'DOCUMENTS_LIST_ERROR',
+      });
 
       // Manejar diferentes tipos de errores
       if (errorMessage.includes('Bucket de documentos no encontrado')) {
@@ -116,11 +127,18 @@ export class DocumentsController {
     @Param('id') documentId: string,
   ): Promise<DeleteDocumentResponseDto> {
     try {
+      this.logger.logDocumentOperation('delete', documentId);
+      
       const result = await this.deleteDocumentUseCase.execute(documentId);
 
       if (!result.success) {
         // Documento no encontrado
         if (result.error === 'DOCUMENT_NOT_FOUND') {
+          this.logger.warn('Document not found for deletion', {
+            documentId,
+            errorType: 'DOCUMENT_NOT_FOUND',
+          });
+          
           throw new HttpException(
             new DeleteDocumentErrorDto(
               'Document Not Found',
@@ -132,6 +150,11 @@ export class DocumentsController {
         }
 
         // Otros errores
+        this.logger.error('Document deletion failed', result.message, {
+          documentId,
+          errorType: result.error,
+        });
+        
         throw new HttpException(
           new DeleteDocumentErrorDto(
             'Delete Failed',
@@ -141,6 +164,11 @@ export class DocumentsController {
           HttpStatus.INTERNAL_SERVER_ERROR,
         );
       }
+
+      this.logger.log('Document deleted successfully', {
+        documentId,
+        deletedAt: result.deletedAt,
+      });
 
       return new DeleteDocumentResponseDto(
         result.message,
@@ -156,7 +184,11 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in deleteDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in deleteDocument', error instanceof Error ? error : errorMessage, {
+        documentId,
+        errorType: 'UNEXPECTED_ERROR',
+      });
 
       throw new HttpException(
         new DeleteDocumentErrorDto(
@@ -185,7 +217,21 @@ export class DocumentsController {
         throw new BadRequestException('Usuario no autenticado');
       }
 
+      this.logger.setContext({ userId });
+      this.logger.logDocumentOperation('upload', undefined, {
+        fileName: file.originalname,
+        fileSize: file.size,
+        mimeType: file.mimetype,
+      });
+
       const document = await this.uploadDocumentUseCase.execute(file, userId);
+
+      this.logger.log('Document uploaded successfully', {
+        documentId: document.id,
+        fileName: document.fileName,
+        originalName: document.originalName,
+        size: document.size,
+      });
 
       return {
         id: document.id,
@@ -207,7 +253,12 @@ export class DocumentsController {
       // Error inesperado
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in uploadDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in uploadDocument', error instanceof Error ? error : errorMessage, {
+        fileName: file?.originalname,
+        fileSize: file?.size,
+        errorType: 'UPLOAD_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -232,8 +283,16 @@ export class DocumentsController {
         );
       }
 
+      this.logger.logDocumentOperation('download', documentId);
+
       const downloadUrl =
         await this.downloadDocumentUseCase.execute(documentId);
+      
+      this.logger.log('Document download URL generated successfully', {
+        documentId,
+        downloadUrlLength: downloadUrl.length,
+      });
+      
       return { downloadUrl };
     } catch (error) {
       if (
@@ -242,9 +301,14 @@ export class DocumentsController {
       ) {
         throw error;
       }
+      
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in downloadDocument:', errorMessage);
+      
+      this.logger.error('Unexpected error in downloadDocument', error instanceof Error ? error : errorMessage, {
+        documentId,
+        errorType: 'DOWNLOAD_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -263,14 +327,28 @@ export class DocumentsController {
     @Param('documentId') documentId: string,
   ): Promise<{ message: string; success: boolean }> {
     try {
+      this.logger.logDocumentOperation('process', documentId, {
+        operation: 'text_extraction',
+      });
+
       const success = await this.processDocumentTextUseCase.execute(documentId);
 
       if (success) {
+        this.logger.log('Document text processed successfully', {
+          documentId,
+          operation: 'text_extraction',
+        });
+        
         return {
           success: true,
           message: 'Texto extraído exitosamente del documento',
         };
       } else {
+        this.logger.warn('Document text processing failed', {
+          documentId,
+          operation: 'text_extraction',
+        });
+        
         throw new HttpException(
           {
             statusCode: HttpStatus.BAD_REQUEST,
@@ -287,7 +365,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in processDocumentText:', errorMessage);
+      
+      this.logger.error('Unexpected error in processDocumentText', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'text_extraction',
+        errorType: 'PROCESSING_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -325,6 +408,12 @@ export class DocumentsController {
         throw new BadRequestException('ID de documento requerido');
       }
 
+      this.logger.logChunkOperation('process', documentId, undefined, {
+        chunkingConfig: body.chunkingConfig,
+        replaceExisting: body.replaceExisting,
+        chunkType: body.chunkType,
+      });
+
       const result = await this.processDocumentChunksUseCase.execute({
         documentId,
         chunkingConfig: body.chunkingConfig,
@@ -333,6 +422,11 @@ export class DocumentsController {
       });
 
       if (result.status === 'success') {
+        this.logger.logChunkOperation('process', documentId, result.savedChunks.length, {
+          processingTimeMs: result.processingTimeMs,
+          statistics: result.chunkingResult.statistics,
+        });
+        
         return {
           success: true,
           message: 'Chunks procesados exitosamente',
@@ -343,6 +437,12 @@ export class DocumentsController {
           },
         };
       } else {
+        this.logger.error('Chunk processing failed', JSON.stringify(result.errors), {
+          documentId,
+          operation: 'chunk_processing',
+          errors: result.errors,
+        });
+        
         return {
           success: false,
           message: 'Error procesando chunks',
@@ -359,7 +459,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in processDocumentChunks:', errorMessage);
+      
+      this.logger.error('Unexpected error in processDocumentChunks', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'chunk_processing',
+        errorType: 'CHUNK_PROCESSING_ERROR',
+      });
 
       throw new HttpException(
         {
@@ -387,11 +492,20 @@ export class DocumentsController {
         throw new BadRequestException('ID de documento requerido');
       }
 
+      this.logger.logChunkOperation('retrieve', documentId);
+
       // Usar el servicio de chunking para obtener chunks con estadísticas
       const result =
         await this.processDocumentChunksUseCase[
           'chunkingService'
         ].getDocumentChunks(documentId);
+
+      this.logger.log('Document chunks retrieved successfully', {
+        documentId,
+        totalChunks: result.total,
+        chunksReturned: result.chunks.length,
+        statistics: result.statistics,
+      });
 
       return {
         success: true,
@@ -422,7 +536,12 @@ export class DocumentsController {
 
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
-      console.error('Unexpected error in getDocumentChunks:', errorMessage);
+      
+      this.logger.error('Unexpected error in getDocumentChunks', error instanceof Error ? error : errorMessage, {
+        documentId,
+        operation: 'chunk_retrieval',
+        errorType: 'CHUNK_RETRIEVAL_ERROR',
+      });
 
       throw new HttpException(
         {

--- a/backend/src/modules/repository_documents/infrastructure/http/embeddings.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/embeddings.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 import { IsString, IsNotEmpty, IsOptional, IsBoolean } from 'class-validator';
+import { ContextualLoggerService } from '../services/contextual-logger.service';
 import { GenerateDocumentEmbeddingsUseCase } from '../../application/use-cases/generate-document-embeddings.use-case';
 import { SearchDocumentsUseCase } from '../../application/use-cases/search-documents.use-case';
 
@@ -87,6 +88,7 @@ export class EmbeddingsController {
   constructor(
     private readonly generateEmbeddingsUseCase: GenerateDocumentEmbeddingsUseCase,
     private readonly searchDocumentsUseCase: SearchDocumentsUseCase,
+    private readonly contextualLogger: ContextualLoggerService,
   ) {}
 
   /**
@@ -176,7 +178,7 @@ export class EmbeddingsController {
   ) {
     try {
       this.logger.log(
-        `🚀 Iniciando generación de embeddings para documento: ${documentId}`,
+        ` Iniciando generación de embeddings para documento: ${documentId}`,
       );
       const startTime = Date.now();
 
@@ -311,10 +313,10 @@ export class EmbeddingsController {
   async searchDocuments(@Body() dto: SemanticSearchDto) {
     try {
       // Debug: Ver qué está llegando
-      this.logger.log(`📨 DTO recibido:`, JSON.stringify(dto, null, 2));
-      this.logger.log(`📊 Tipo de dto:`, typeof dto);
-      this.logger.log(`📊 Tipo de query:`, typeof dto?.query);
-      this.logger.log(`📊 Query value:`, dto?.query);
+      this.logger.log(` DTO recibido:`, JSON.stringify(dto, null, 2));
+      this.logger.log(` Tipo de dto:`, typeof dto);
+      this.logger.log(` Tipo de query:`, typeof dto?.query);
+      this.logger.log(` Query value:`, dto?.query);
 
       // Validación adicional de entrada
       if (!dto || !dto.query || typeof dto.query !== 'string') {
@@ -359,7 +361,7 @@ export class EmbeddingsController {
       }
 
       this.logger.log(
-        `✅ Búsqueda completada: ${result.result?.totalResults || 0} resultados en ${processingTime}ms`,
+        ` Búsqueda completada: ${result.result?.totalResults || 0} resultados en ${processingTime}ms`,
       );
 
       return {

--- a/backend/src/modules/repository_documents/infrastructure/http/middleware/logging.middleware.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/middleware/logging.middleware.ts
@@ -1,0 +1,73 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface LoggingRequest extends Request {
+  requestId?: string;
+  startTime?: number;
+}
+
+@Injectable()
+export class LoggingMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('DocumentsAPI');
+
+  use(req: LoggingRequest, res: Response, next: NextFunction) {
+    // Generar ID único para la petición
+    req.requestId = uuidv4();
+    req.startTime = Date.now();
+
+    // Log de inicio de petición
+    this.logger.log(
+      `[${req.requestId}] ${req.method} ${req.url} - Request started`,
+      {
+        requestId: req.requestId,
+        method: req.method,
+        url: req.url,
+        userAgent: req.headers['user-agent'],
+        ip: req.ip,
+        timestamp: new Date().toISOString(),
+      },
+    );
+
+    // Interceptar la respuesta para loggear el final
+    const originalSend = res.send;
+    res.send = function (body: any) {
+      const duration = Date.now() - (req.startTime || 0);
+      
+      const logLevel = res.statusCode >= 400 ? 'error' : 'log';
+      const logMessage = `[${req.requestId}] ${req.method} ${req.url} - ${res.statusCode} - ${duration}ms`;
+      
+      if (logLevel === 'error') {
+        Logger.prototype.error.call(
+          new Logger('DocumentsAPI'),
+          logMessage,
+          {
+            requestId: req.requestId,
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode,
+            duration,
+            timestamp: new Date().toISOString(),
+          },
+        );
+      } else {
+        Logger.prototype.log.call(
+          new Logger('DocumentsAPI'),
+          logMessage,
+          {
+            requestId: req.requestId,
+            method: req.method,
+            url: req.url,
+            statusCode: res.statusCode,
+            duration,
+            timestamp: new Date().toISOString(),
+          },
+        );
+      }
+
+      return originalSend.call(this, body);
+    };
+
+    next();
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/services/contextual-logger.service.ts
+++ b/backend/src/modules/repository_documents/infrastructure/services/contextual-logger.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger, Scope, Inject } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import type { LoggingRequest } from '../http/middleware/logging.middleware';
+
+export interface LogContext {
+  requestId?: string;
+  userId?: string;
+  action?: string;
+  resource?: string;
+  metadata?: Record<string, any>;
+}
+
+@Injectable({ scope: Scope.REQUEST })
+export class ContextualLoggerService {
+  private readonly logger = new Logger('DocumentsService');
+  private context: LogContext = {};
+
+  constructor(@Inject(REQUEST) private request: LoggingRequest) {
+    // Extraer requestId del request
+    this.context.requestId = this.request.requestId;
+  }
+
+  setContext(context: Partial<LogContext>) {
+    this.context = { ...this.context, ...context };
+  }
+
+  private formatMessage(message: string, additionalContext?: Record<string, any>) {
+    const fullContext = {
+      ...this.context,
+      ...additionalContext,
+      timestamp: new Date().toISOString(),
+    };
+
+    const contextStr = this.context.requestId 
+      ? `[${this.context.requestId}]` 
+      : '';
+
+    return {
+      message: `${contextStr} ${message}`,
+      context: fullContext,
+    };
+  }
+
+  log(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.log(formatted.message, formatted.context);
+  }
+
+  error(message: string, error?: Error | string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, {
+      ...context,
+      error: error instanceof Error ? {
+        name: error.name,
+        message: error.message,
+        stack: error.stack,
+      } : error,
+    });
+    this.logger.error(formatted.message, formatted.context);
+  }
+
+  warn(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.warn(formatted.message, formatted.context);
+  }
+
+  debug(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.debug(formatted.message, formatted.context);
+  }
+
+  verbose(message: string, context?: Record<string, any>) {
+    const formatted = this.formatMessage(message, context);
+    this.logger.verbose(formatted.message, formatted.context);
+  }
+
+  // Métodos específicos para el dominio de documentos
+  logDocumentOperation(
+    operation: 'upload' | 'download' | 'delete' | 'process' | 'list',
+    documentId?: string,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: operation,
+      resource: 'document',
+      metadata: { documentId, ...additionalContext },
+    });
+    
+    this.log(`Document ${operation} operation`, {
+      documentId,
+      ...additionalContext,
+    });
+  }
+
+  logChunkOperation(
+    operation: 'create' | 'process' | 'retrieve',
+    documentId: string,
+    chunkCount?: number,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: `chunk_${operation}`,
+      resource: 'document_chunk',
+      metadata: { documentId, chunkCount, ...additionalContext },
+    });
+
+    this.log(`Chunk ${operation} operation for document`, {
+      documentId,
+      chunkCount,
+      ...additionalContext,
+    });
+  }
+
+  logEmbeddingOperation(
+    operation: 'generate' | 'search',
+    documentId?: string,
+    additionalContext?: Record<string, any>
+  ) {
+    this.setContext({
+      action: `embedding_${operation}`,
+      resource: 'embedding',
+      metadata: { documentId, ...additionalContext },
+    });
+
+    this.log(`Embedding ${operation} operation`, {
+      documentId,
+      ...additionalContext,
+    });
+  }
+}


### PR DESCRIPTION
### Changes and Implementations
**Implementations:**

-  Middleware of logging (repository_documents/http/middleware/logging.middleware.ts); It generates an unic ID (UUID) for each request, also captures the begin and end of each petition and register the information of the user (User-agent, IP)
- Contextual logging(backend/src/modules/repository_documents/infrastructure/services/contextual-logger.service.ts); Automatically injects the ID request in the logs, put the logs in a structured context. 

**Changes:**
- Integration in controller (backend/src/modules/repository_documents/infrastructure/http/documents.controller.ts); Now all methods use the contextual logger and for each one there are specific logs. 
- Configuration of the Documents Module (backend/src/modules/repository_documents/documents.module.ts); The logging middleware it's applied correctly in each document route. The contextual service is available as provider. 

> [!IMPORTANT]  
> The project and the docker container has to be running.

> Steps to test the feature
- Go to the path: LearningAgent-Project\Learning-Agent\backend and put the command: npm run start
- Go to docker desktop and put on the docker container
- Go to postman and put the following URL: localhost:3000/api/documents/upload
- On the body put file, and upload any pdf, then send the petition
- If something goes wrong, it's gonna give you the next image

### Examples 

![Imagen de WhatsApp 2025-09-03 a las 20 21 39_8b702220](https://github.com/user-attachments/assets/c328b447-1370-4f70-b24f-56903f0d2f56)
