### PR TITLE
Fix[MD-101]: configMinioVolumes

### DIFF
--- a/infra/docker/minio.compose.yml
+++ b/infra/docker/minio.compose.yml
@@ -7,7 +7,6 @@ services:
       - "9000:9000"
       - "9090:9090"
     volumes:
-      - /tmp/data:/data
       - ./minio-data:/data
     env_file:
       - .env


### PR DESCRIPTION
 - Changes:
MinIO Service Configuration (infra/docker/minio.compose.yml): The incorrect volume mapping - /tmp/data:/data has been removed. This line was causing a configuration conflict that prevented files from being correctly persisted in the MinIO storage, leading to errors during the PDF upload process in the documents module.

 - Important
To properly test this fix, it's crucial to ensure that any old Docker volumes associated with MinIO are removed, as they might retain the faulty configuration.

Stop any running containers with docker-compose down.

To remove the associated volumes, use the command docker-compose down -v.

Examples
<img width="904" height="562" alt="image" src="https://github.com/user-attachments/assets/a852f9b8-97a4-440b-9f1f-9aeab5dde46e" />

<img width="929" height="560" alt="image" src="https://github.com/user-attachments/assets/1bd17fcc-c721-40df-afe8-e8df49c00a6d" />


