### PR TITLE
Fix del bug [MD-86]tooltips_duplicados en los encabezados de la tabla de documentos

### DIFF
--- a/client/src/components/documents/DocumentTable.tsx
+++ b/client/src/components/documents/DocumentTable.tsx
@@ -40,9 +40,6 @@ export const DocumentTable = ({
       dataIndex: 'originalName',
       key: 'originalName',
       sorter: (a: Document, b: Document) => a.originalName.localeCompare(b.originalName),
-      showSorterTooltip: {
-        title: 'Ordenar por nombre de archivo'
-      },
     },
     {
       title: (
@@ -54,9 +51,6 @@ export const DocumentTable = ({
       key: 'uploadedAt',
       sorter: (a: Document, b: Document) =>
         new Date(a.uploadedAt).getTime() - new Date(b.uploadedAt).getTime(),
-      showSorterTooltip: {
-        title: 'Ordenar por fecha de subida'
-      },
       render: (date: string) => new Date(date).toLocaleDateString('es-ES'),
     },
     {
@@ -68,9 +62,6 @@ export const DocumentTable = ({
       dataIndex: 'size',
       key: 'size',
       sorter: (a: Document, b: Document) => a.size - b.size,
-      showSorterTooltip: {
-        title: 'Ordenar por tamaño de archivo'
-      },
       render: (size: number) => {
         const kb = size / 1024;
         if (kb < 1024) return `${kb.toFixed(2)} KB`;
@@ -166,8 +157,8 @@ export const DocumentTable = ({
       className="academic-table"
       locale={{
         emptyText: 'No hay documentos en el repositorio',
-        triggerDesc: 'Ordenar descendente',
-        triggerAsc: 'Ordenar ascendente',
+        triggerDesc: '',
+        triggerAsc: '',
         cancelSort: 'Cancelar ordenamiento'
       }}
       scroll={{ x: 800 }}


### PR DESCRIPTION
Se corrigió el bug que generaba tooltips duplicados en los encabezados de la tabla de documentos, asegurando una visualización más limpia y consistente.