### PR TITLE
fix(MD-87): eliminar background hard-coded en CustomCard para soporta…

### DIFF
--- a/client/src/components/shared/CustomCard.tsx
+++ b/client/src/components/shared/CustomCard.tsx
@@ -402,7 +402,6 @@ const Root: React.FC<RootProps> & {
         width: cardWidth,
         height: cardHeight,
         borderRadius: 14,
-        background: "#fff",
         position: "relative",
         overflow: "hidden",
         ...style,


### PR DESCRIPTION
# Resumen
Se corrige el comportamiento visual de `CustomCard` en Dark Mode eliminando el fondo hard-coded que forzaba un fondo blanco. Con este cambio, el card ahora respeta las variables/estilos del tema y evita elementos con fondo blanco en modo oscuro.

# Qué se hizo
- Eliminación de la propiedad hard-coded `background: "#fff"` en `CustomCard.tsx`.
- Archivo modificado: `CustomCard.tsx` (único cambio en esta PR).
- Con esto, el componente toma el fondo definido por el theme/estilos globales y mejora la apariencia en modo oscuro.

# Por qué
- Evita que las tarjetas aparezcan con fondo blanco en Dark Mode, mejorando la consistencia visual.
- Mejora la accesibilidad y la experiencia de usuario en temas oscuros.
- Facilita que el componente herede correctamente variables de tema (light/dark).

# Cómo probar / QA
1. Loggearse en la aplicación (si aplica).
2. Navegar a vistas donde se renderice `CustomCard` (dashboard, listados, etc.).
3. Alternar Dark Mode (activar / desactivar).
4. Verificar:
   - En Dark Mode **no** aparecerán tarjetas con fondo blanco; el fondo debe corresponder al tema oscuro.
   - En Light Mode el card mantiene buena legibilidad y contraste.
   - Sombras, bordes y textos se ven coherentes con el tema activo.
5. Probar en al menos 2 navegadores (Chrome y Firefox) y verificar en vistas responsive (desktop y mobile).
6. Revisar componentes que reutilizan `CustomCard` para asegurarse de que su apariencia global no se vea afectada.

# Archivos modificados
- `CustomCard.tsx` — eliminado: `background: "#fff"`

# Captura

![prueba](https://github.com/user-attachments/assets/121e17eb-b900-4b6e-9077-2f7e6ed4ed41)
