### PR TITLE
feat[MD-91]: Endpoint contract to communicate with other modules

### DIFF
--- a/backend/CONTRACT_ENDPOINTS_DOCUMENTATION.md
+++ b/backend/CONTRACT_ENDPOINTS_DOCUMENTATION.md
@@ -1,0 +1,134 @@
+# Documentación de Endpoints del Contrato - API de Contexto de Materias
+
+## Resumen de la Implementación
+
+Se han implementado los endpoints requeridos por el contrato para proporcionar acceso a los documentos cargados por profesores para materias específicas.
+
+## Base URL
+`/api/v1/documentos`
+
+## Autenticación
+JWT Bearer Token (enviado en header `Authorization: Bearer <token>`)
+
+## Endpoints Implementados
+
+### 1. GET /materias/{materiaId}/documentos
+
+**Descripción:** Obtiene la lista de documentos disponibles para una materia.
+
+**Parámetros de Ruta:**
+- `materiaId` (string, requerido): ID de la materia (e.g., "mate1")
+
+**Parámetros de Consulta:**
+- `tipo` (string, opcional): Filtrar por tipo (e.g., "pdf", "libro"). Default: todos
+- `page` (integer, opcional): Página para paginación. Default: 1
+- `limit` (integer, opcional): Límite por página. Default: 10
+
+**Respuesta Exitosa (200 OK):**
+```json
+{
+  "documentos": [
+    {
+      "id": "doc123",
+      "titulo": "Libro de Matemáticas Básicas",
+      "tipo": "pdf",
+      "url": "https://storage.example.com/doc123.pdf",
+      "fechaCarga": "2025-09-01T00:00:00Z",
+      "profesorId": "prof456"
+    }
+  ],
+  "total": 5,
+  "pagina": 1
+}
+```
+
+**Controlador:** `ContractDocumentsController.getDocumentsBySubject()`
+**Caso de Uso:** `GetDocumentsBySubjectUseCase`
+
+### 2. GET /documentos/{docId}/contenido
+
+**Descripción:** Obtiene el contenido extraído de un documento específico (texto plano para procesamiento).
+
+**Parámetros de Ruta:**
+- `docId` (string, requerido): ID del documento
+
+**Respuesta Exitosa (200 OK):**
+```json
+{
+  "contenido": "Texto extraído del PDF... (puede ser largo, con secciones)",
+  "metadata": {
+    "paginas": 150,
+    "resumen": "Resumen generado por IA si aplica"
+  }
+}
+```
+
+**Controlador:** `ContractDocumentsController.getDocumentContent()`
+**Caso de Uso:** `GetDocumentContentUseCase`
+
+## Cambios en la Base de Datos
+
+### Migración Aplicada: `20250907011252_add_document_course_relation`
+
+**Cambios realizados:**
+1. ✅ Campo `courseId` opcional agregado a la tabla `Document`
+2. ✅ Índice `Document_courseId_idx` para optimizar consultas
+3. ✅ Clave foránea `Document_courseId_fkey` con `ON DELETE SET NULL`
+
+## Arquitectura de la Implementación
+
+### Casos de Uso Creados
+- `GetDocumentsBySubjectUseCase`: Lista documentos filtrados por materia/curso
+- `GetDocumentContentUseCase`: Obtiene el contenido extraído de un documento
+
+### DTOs Creados
+- `ContractDocumentItemDto`: DTO específico para el contrato con `profesorId`
+- `ContractDocumentListResponseDto`: Respuesta que cumple con el formato del contrato
+- `DocumentContentResponseDto`: Respuesta para el contenido del documento
+
+### Controlador
+- `ContractDocumentsController`: Nuevo controlador específico para los endpoints del contrato
+
+### Repositorio Extendido
+- `DocumentRepositoryPort`: Agregados métodos `findByCourseId()` y `associateWithCourse()`
+- `PrismaDocumentRepositoryAdapter`: Implementación de los nuevos métodos
+
+## Estado de la Implementación
+
+ **Completado:**
+- Migración de base de datos aplicada
+- Casos de uso implementados
+- DTOs creados según el contrato
+- Controlador implementado
+- Repositorio extendido
+- Módulo actualizado con nuevos providers
+- Compilación exitosa
+
+
+
+## Comandos Útiles
+
+```bash
+# Aplicar migraciones
+npx prisma migrate deploy
+
+# Ver estado de migraciones
+npx prisma migrate status
+
+# Generar cliente Prisma
+npx prisma generate
+
+# Iniciar servidor de desarrollo
+npm run start:dev
+
+# Compilar proyecto
+npm run build
+```
+
+## Notas Técnicas
+
+- Los endpoints mantienen compatibilidad con la implementación existente
+- Se utiliza arquitectura hexagonal (puertos y adaptadores)
+- Los DTOs cumplen exactamente con el contrato especificado
+- La relación Document-Course es opcional (no rompe documentos existentes)
+- Se aprovecha la infraestructura existente de S3, autenticación y extracción de texto

--- a/backend/POSTMAN_TESTING_GUIDE.md
+++ b/backend/POSTMAN_TESTING_GUIDE.md
@@ -1,0 +1,256 @@
+# Guía de Testing con Postman - Contract Endpoints
+
+## Información General
+
+**Base URL:** `http://localhost:3000`  
+**Autenticación:** JWT Bearer Token requerido para algunos endpoints
+
+## Pre-requisitos
+
+### 1. Iniciar el servidor
+```bash
+# Desde el directorio backend
+npm run start:dev
+```
+
+### 2. Crear datos de prueba (opcional)
+Ejecutar el seed de Prisma si existe:
+```bash
+npx prisma db seed
+```
+
+## Endpoints Implementados
+
+### 1. **GET** - Listar documentos por materia
+**Endpoint:** `/api/v1/documentos/materias/{materiaId}/documentos`
+
+#### Configuración en Postman:
+- **Método:** GET
+- **URL:** `http://localhost:3000/api/v1/documentos/materias/course-uuid-aqui/documentos`
+- **Headers:**
+  ```
+  Authorization: Bearer YOUR_JWT_TOKEN_HERE
+  Content-Type: application/json
+  ```
+- **Query Parameters (opcionales):**
+  - `tipo`: pdf, libro, etc.
+  - `page`: 1, 2, 3... (default: 1)
+  - `limit`: 10, 20, 50... (default: 10)
+
+#### Ejemplo de URL completa:
+```
+http://localhost:3000/api/v1/documentos/materias/123e4567-e89b-12d3-a456-426614174000/documentos?tipo=pdf&page=1&limit=10
+```
+
+#### Respuesta esperada (200 OK):
+```json
+{
+  "documentos": [
+    {
+      "id": "doc123",
+      "titulo": "Libro de Matemáticas Básicas", 
+      "tipo": "pdf",
+      "url": "https://storage.example.com/doc123.pdf",
+      "fechaCarga": "2025-09-01T00:00:00Z",
+      "profesorId": "prof456"
+    }
+  ],
+  "total": 5,
+  "pagina": 1
+}
+```
+
+---
+
+### 2. **GET** - Obtener contenido de documento
+**Endpoint:** `/api/v1/documentos/{docId}/contenido`
+
+#### Configuración en Postman:
+- **Método:** GET
+- **URL:** `http://localhost:3000/api/v1/documentos/document-uuid-aqui/contenido`
+- **Headers:**
+  ```
+  Authorization: Bearer YOUR_JWT_TOKEN_HERE
+  Content-Type: application/json
+  ```
+
+#### Ejemplo de URL:
+```
+http://localhost:3000/api/v1/documentos/456e7890-e89b-12d3-a456-426614174001/contenido
+```
+
+#### Respuesta esperada (200 OK):
+```json
+{
+  "contenido": "Texto extraído del PDF... (puede ser largo, con secciones)",
+  "metadata": {
+    "paginas": 150,
+    "resumen": "Resumen generado por IA si aplica"
+  }
+}
+```
+
+---
+
+### 3. **POST** - Asociar documento con curso (endpoint adicional)
+**Endpoint:** `/api/documents/{documentId}/associate-course/{courseId}`
+
+#### Configuración en Postman:
+- **Método:** POST
+- **URL:** `http://localhost:3000/api/documents/document-uuid/associate-course/course-uuid`
+- **Headers:**
+  ```
+  Authorization: Bearer YOUR_JWT_TOKEN_HERE
+  Content-Type: application/json
+  ```
+
+#### Respuesta esperada (200 OK):
+```json
+{
+  "success": true,
+  "message": "Documento asociado con el curso exitosamente",
+  "documentId": "document-uuid",
+  "courseId": "course-uuid"
+}
+```
+
+---
+
+
+---
+
+## Obtener Token JWT para Testing
+
+### 1. Login Endpoint
+**Endpoint:** `/api/auth/login` (si existe)
+
+#### Configuración:
+- **Método:** POST
+- **URL:** `http://localhost:3000/api/auth/login`
+- **Body (JSON):**
+  ```json
+  {
+    "email": "usuario@ejemplo.com",
+    "password": "password123"
+  }
+  ```
+
+#### Respuesta:
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "user": {
+    "id": "user-uuid",
+    "email": "usuario@ejemplo.com"
+  }
+}
+```
+
+### 2. Usar el token
+Copiar el `access_token` y usarlo en el header `Authorization: Bearer <token>`
+
+---
+
+## IDs de Ejemplo para Testing
+
+Para realizar las pruebas necesitarás IDs reales de tu base de datos. Puedes obtenerlos ejecutando:
+
+```sql
+-- Obtener IDs de cursos
+SELECT id, name FROM "Course" LIMIT 5;
+
+-- Obtener IDs de documentos
+SELECT id, "originalName", "uploadedBy" FROM "Document" LIMIT 5;
+
+-- Obtener IDs de usuarios
+SELECT id, email FROM "User" LIMIT 5;
+```
+
+---
+
+## Configuración de Colección Postman
+
+### Variables de Entorno
+Crear las siguientes variables en Postman:
+
+- `baseUrl`: `http://localhost:3000`
+- `authToken`: `Bearer your-jwt-token-here`
+- `courseId`: `uuid-del-curso`
+- `documentId`: `uuid-del-documento`
+
+### Headers Globales
+```
+Authorization: {{authToken}}
+Content-Type: application/json
+```
+
+---
+
+## Troubleshooting
+
+### Error: "Cannot read properties of undefined"
+- Verificar que el servidor esté corriendo
+- Verificar que la base de datos esté conectada
+- Verificar que las migraciones estén aplicadas
+
+### Error: "Unauthorized"
+- Verificar que el token JWT esté en el header
+- Verificar que el token no haya expirado
+- Verificar el formato: `Bearer <token>`
+
+### Error: "Not Found"
+- Verificar que los UUIDs sean válidos
+- Verificar que los recursos existan en la base de datos
+- Verificar la URL del endpoint
+
+---
+
+## Scripts de Automatización Postman
+
+### Pre-request Script (para obtener token automáticamente):
+```javascript
+// Pre-request script para login automático
+const loginRequest = {
+  url: pm.environment.get("baseUrl") + "/api/auth/login",
+  method: 'POST',
+  header: {
+    'Content-Type': 'application/json',
+  },
+  body: {
+    mode: 'raw',
+    raw: JSON.stringify({
+      email: "test@example.com",
+      password: "password123"
+    })
+  }
+};
+
+pm.sendRequest(loginRequest, (err, response) => {
+  if (err) {
+    console.log('Error during login:', err);
+  } else {
+    const responseJson = response.json();
+    pm.environment.set("authToken", "Bearer " + responseJson.access_token);
+  }
+});
+```
+
+### Test Script (para validar respuestas):
+```javascript
+// Test script para validar respuesta
+pm.test("Status code is 200", function () {
+    pm.response.to.have.status(200);
+});
+
+pm.test("Response has required fields", function () {
+    const jsonData = pm.response.json();
+    pm.expect(jsonData).to.have.property('documentos');
+    pm.expect(jsonData).to.have.property('total');
+    pm.expect(jsonData).to.have.property('pagina');
+});
+
+pm.test("Documents array is not empty", function () {
+    const jsonData = pm.response.json();
+    pm.expect(jsonData.documentos).to.be.an('array');
+});
+```

--- a/backend/prisma/migrations/20250907011252_add_document_course_relation/migration.sql
+++ b/backend/prisma/migrations/20250907011252_add_document_course_relation/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "public"."Document" ADD COLUMN     "courseId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Document_courseId_idx" ON "public"."Document"("courseId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Document" ADD CONSTRAINT "Document_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "public"."Course"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -150,6 +150,10 @@ model Document {
   uploadedBy       String
   uploader         User                      @relation(fields: [uploadedBy], references: [id])
   
+  // Relación opcional con Course/Materia para el contrato de documentos
+  courseId         String?
+  course           Course?                   @relation(fields: [courseId], references: [id])
+  
   // Relations para RAG
   chunks           DocumentChunk[]
   categories       DocumentCategoryMapping[]
@@ -168,6 +172,7 @@ model Document {
   @@index([uploadedBy])
   @@index([fileHash])
   @@index([contentType])
+  @@index([courseId])
 }
 
 model DocumentChunk {
@@ -364,6 +369,9 @@ model Course {
   teacherId     String
   teacher       TeacherProfile    @relation(fields: [teacherId], references: [userId])
   classes       Classes[]
+  
+  // Relación con documentos para el contrato
+  documents     Document[]
 
   createdAt     DateTime          @default(now())
   updatedAt     DateTime          @updatedAt

--- a/backend/src/modules/repository_documents/application/commands/associate-document-course.usecase.ts
+++ b/backend/src/modules/repository_documents/application/commands/associate-document-course.usecase.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import type { DocumentRepositoryPort } from '../../domain/ports/document-repository.port';
+
+export interface AssociateDocumentToCourseRequest {
+  documentId: string;
+  courseId: string;
+}
+
+export interface AssociateDocumentToCourseResponse {
+  success: boolean;
+  message: string;
+  documentId: string;
+  courseId: string;
+}
+
+@Injectable()
+export class AssociateDocumentToCourseUseCase {
+  constructor(
+    private readonly documentRepository: DocumentRepositoryPort,
+  ) {}
+
+  async execute(
+    request: AssociateDocumentToCourseRequest,
+  ): Promise<AssociateDocumentToCourseResponse> {
+    const { documentId, courseId } = request;
+
+    try {
+      // Verificar que el documento existe
+      const document = await this.documentRepository.findById(documentId);
+      if (!document) {
+        return {
+          success: false,
+          message: `Documento con ID ${documentId} no encontrado`,
+          documentId,
+          courseId,
+        };
+      }
+
+      // Asociar el documento con el curso
+      await this.documentRepository.associateWithCourse(documentId, courseId);
+
+      return {
+        success: true,
+        message: 'Documento asociado exitosamente con el curso',
+        documentId,
+        courseId,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      
+      return {
+        success: false,
+        message: `Error al asociar documento con curso: ${errorMessage}`,
+        documentId,
+        courseId,
+      };
+    }
+  }
+}

--- a/backend/src/modules/repository_documents/application/queries/get-document-content.usecase.ts
+++ b/backend/src/modules/repository_documents/application/queries/get-document-content.usecase.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import type { DocumentRepositoryPort } from '../../domain/ports/document-repository.port';
+
+export interface GetDocumentContentRequest {
+  docId: string;
+}
+
+export interface GetDocumentContentResponse {
+  contenido: string;
+  metadata: {
+    paginas?: number;
+    resumen?: string;
+  };
+}
+
+@Injectable()
+export class GetDocumentContentUseCase {
+  constructor(
+    private readonly documentRepository: DocumentRepositoryPort,
+  ) {}
+
+  async execute(
+    request: GetDocumentContentRequest,
+  ): Promise<GetDocumentContentResponse> {
+    const { docId } = request;
+
+    try {
+      // Buscar el documento por ID
+      const document = await this.documentRepository.findById(docId);
+
+      if (!document) {
+        throw new Error(`Documento con ID ${docId} no encontrado`);
+      }
+
+      // Verificar que el documento tenga texto extraído
+      if (!document.extractedText) {
+        throw new Error(
+          `El documento ${docId} no tiene contenido de texto extraído`,
+        );
+      }
+
+      // Construir la respuesta con el contenido y metadata
+      const response: GetDocumentContentResponse = {
+        contenido: document.extractedText,
+        metadata: {
+          paginas: document.pageCount || undefined,
+          resumen: undefined, // Por ahora no generamos resúmenes automáticos
+        },
+      };
+
+      return response;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(
+        `Error al obtener contenido del documento ${docId}: ${errorMessage}`,
+      );
+    }
+  }
+}

--- a/backend/src/modules/repository_documents/application/queries/get-documents-by-subject.usecase.ts
+++ b/backend/src/modules/repository_documents/application/queries/get-documents-by-subject.usecase.ts
@@ -1,0 +1,99 @@
+import { Injectable } from '@nestjs/common';
+import type { DocumentRepositoryPort } from '../../domain/ports/document-repository.port';
+import type { DocumentStoragePort } from '../../domain/ports/document-storage.port';
+import { ContractDocumentListItem } from '../../domain/entities/contract-document-list-item';
+
+export interface GetDocumentsBySubjectRequest {
+  materiaId: string;
+  tipo?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface GetDocumentsBySubjectResponse {
+  docs: ContractDocumentListItem[];
+  total: number;
+  page: number;
+}
+
+@Injectable()
+export class GetDocumentsBySubjectUseCase {
+  constructor(
+    private readonly documentRepository: DocumentRepositoryPort,
+    private readonly documentStorage: DocumentStoragePort,
+  ) {}
+
+  async execute(
+    request: GetDocumentsBySubjectRequest,
+  ): Promise<GetDocumentsBySubjectResponse> {
+    const { materiaId, tipo, page = 1, limit = 10 } = request;
+
+    // Calcular offset para paginación
+    const offset = (page - 1) * limit;
+
+    try {
+      // Obtener documentos de la base de datos filtrados por curso
+      const dbDocuments = await this.documentRepository.findByCourseId(
+        materiaId,
+        offset,
+        limit,
+        tipo,
+      );
+
+      // Obtener el total de documentos para la materia
+      const total = await this.documentRepository.countByCourseId(
+        materiaId,
+        tipo,
+      );
+
+      // Crear ContractDocumentListItem con datos correctos
+      const documents: ContractDocumentListItem[] = [];
+
+      for (const doc of dbDocuments) {
+        try {
+          // Verificar que el archivo existe en el storage
+          const exists = await this.documentStorage.documentExists(
+            doc.fileName,
+          );
+          if (!exists) continue;
+
+          // Generar URL de descarga
+          const downloadUrl = await this.documentStorage.generateDownloadUrl(
+            doc.fileName,
+          );
+
+          documents.push(
+            new ContractDocumentListItem(
+              doc.id,
+              doc.fileName,
+              doc.originalName,
+              doc.mimeType,
+              doc.size,
+              downloadUrl,
+              doc.uploadedAt,
+              doc.uploadedBy,
+            ),
+          );
+        } catch (error) {
+          // Si hay error con un documento específico, lo omitimos pero continuamos
+          console.warn(
+            `Error processing document ${doc.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          );
+          continue;
+        }
+      }
+
+      return {
+        docs: documents,
+        total,
+        page,
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(
+        `Error al obtener documentos de la materia ${materiaId}: ${errorMessage}`,
+      );
+    }
+  }
+}

--- a/backend/src/modules/repository_documents/domain/entities/contract-document-list-item.ts
+++ b/backend/src/modules/repository_documents/domain/entities/contract-document-list-item.ts
@@ -1,0 +1,24 @@
+export class ContractDocumentListItem {
+  constructor(
+    public readonly id: string,
+    public readonly fileName: string,
+    public readonly originalName: string,
+    public readonly mimeType: string,
+    public readonly size: number,
+    public readonly downloadUrl: string,
+    public readonly uploadedAt: Date,
+    public readonly uploadedBy: string,
+  ) {}
+  toJSON() {
+    return {
+      id: this.id,
+      fileName: this.fileName,
+      originalName: this.originalName,
+      mimeType: this.mimeType,
+      size: this.size,
+      downloadUrl: this.downloadUrl,
+      uploadedAt: this.uploadedAt,
+      uploadedBy: this.uploadedBy,
+    };
+  }
+}

--- a/backend/src/modules/repository_documents/domain/ports/document-repository.port.ts
+++ b/backend/src/modules/repository_documents/domain/ports/document-repository.port.ts
@@ -100,4 +100,38 @@ export interface DocumentRepositoryPort {
    * @returns Número de documentos con el estado especificado
    */
   countByStatus(status: DocumentStatus): Promise<number>;
+
+  /**
+   * Lista documentos por curso/materia con paginación
+   * @param courseId ID del curso/materia
+   * @param offset Número de registros a saltar
+   * @param limit Número máximo de registros a retornar
+   * @param tipo Filtro opcional por tipo de archivo
+   * @returns Lista de documentos del curso
+   */
+  findByCourseId(
+    courseId: string,
+    offset?: number,
+    limit?: number,
+    tipo?: string,
+  ): Promise<Document[]>;
+
+  /**
+   * Cuenta documentos por curso/materia
+   * @param courseId ID del curso/materia
+   * @param tipo Filtro opcional por tipo de archivo
+   * @returns Número de documentos del curso
+   */
+  countByCourseId(courseId: string, tipo?: string): Promise<number>;
+
+  /**
+   * Asocia un documento con un curso/materia
+   * @param documentId ID del documento
+   * @param courseId ID del curso/materia
+   * @returns Documento actualizado o undefined si no existe
+   */
+  associateWithCourse(
+    documentId: string,
+    courseId: string,
+  ): Promise<Document | undefined>;
 }

--- a/backend/src/modules/repository_documents/infrastructure/http/contract-documents.controller.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/contract-documents.controller.ts
@@ -1,0 +1,243 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  HttpException,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ContextualLoggerService } from '../services/contextual-logger.service';
+import { GetDocumentsBySubjectUseCase } from '../../application/queries/get-documents-by-subject.usecase';
+import { GetDocumentContentUseCase } from '../../application/queries/get-document-content.usecase';
+import {
+  ContractDocumentListResponseDto,
+  ContractDocumentItemDto,
+  DocumentContentResponseDto,
+  DocumentContentMetadataDto,
+  GetDocumentsBySubjectQueryDto,
+} from './dtos/contract-documents.dto';
+
+/**
+ * Controlador para endpoints del contrato con el módulo de estudiantes
+ * Base URL: /api/v1/documentos
+ */
+@Controller('api/v1/documentos')
+@UseGuards(AuthGuard('jwt'))
+export class ContractDocumentsController {
+  constructor(
+    private readonly getDocumentsBySubjectUseCase: GetDocumentsBySubjectUseCase,
+    private readonly getDocumentContentUseCase: GetDocumentContentUseCase,
+    private readonly logger: ContextualLoggerService,
+  ) {}
+
+  /**
+   * GET /materias/{materiaId}/documentos
+   * Obtiene la lista de documentos disponibles para una materia.
+   */
+  @Get('materias/:materiaId/documentos')
+  async getDocumentsBySubject(
+    @Param('materiaId') materiaId: string,
+    @Query() query: GetDocumentsBySubjectQueryDto,
+  ): Promise<ContractDocumentListResponseDto> {
+    try {
+      this.logger.logDocumentOperation('list', undefined, {
+        materiaId,
+        query,
+      });
+
+      if (!materiaId || !materiaId.trim()) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: 'ID de materia es requerido',
+            error: 'Bad Request',
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const result = await this.getDocumentsBySubjectUseCase.execute({
+        materiaId: materiaId.trim(),
+        tipo: query.tipo,
+        page: query.page || 1,
+        limit: query.limit || 10,
+      });
+
+      // Mapear la respuesta del dominio a DTOs del contrato
+      const documentos = result.docs.map(
+        (doc) =>
+          new ContractDocumentItemDto(
+            doc.id,
+            doc.originalName, // titulo
+            this.extractFileType(doc.mimeType), // tipo
+            doc.downloadUrl, // url
+            doc.uploadedAt, // fechaCarga
+            doc.uploadedBy, // profesorId
+          ),
+      );
+
+      this.logger.log('Documents retrieved successfully for subject', {
+        materiaId,
+        totalDocuments: result.total,
+        documentsReturned: documentos.length,
+        page: result.page,
+      });
+
+      return new ContractDocumentListResponseDto(
+        documentos,
+        result.total,
+        result.page,
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      this.logger.error(
+        'Error retrieving documents by subject',
+        error instanceof Error ? error : errorMessage,
+        {
+          materiaId,
+          errorType: 'DOCUMENTS_BY_SUBJECT_ERROR',
+        },
+      );
+
+      // Manejar diferentes tipos de errores
+      if (errorMessage.includes('no encontrado')) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.NOT_FOUND,
+            message: 'Materia no encontrada',
+            error: 'Not Found',
+            details: errorMessage,
+          },
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (errorMessage.includes('Servicio de almacenamiento')) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.SERVICE_UNAVAILABLE,
+            message: 'Servicio de almacenamiento no disponible',
+            error: 'Service Unavailable',
+            details: errorMessage,
+          },
+          HttpStatus.SERVICE_UNAVAILABLE,
+        );
+      }
+
+      // Error genérico
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Error interno del servidor al obtener documentos',
+          error: 'Internal Server Error',
+          details: errorMessage,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * GET /documentos/{docId}/contenido
+   * Obtiene el contenido extraído de un documento específico.
+   */
+  @Get(':docId/contenido')
+  async getDocumentContent(
+    @Param('docId') docId: string,
+  ): Promise<DocumentContentResponseDto> {
+    try {
+      this.logger.logDocumentOperation('download', docId);
+
+      if (!docId || !docId.trim()) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: 'ID de documento es requerido',
+            error: 'Bad Request',
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const result = await this.getDocumentContentUseCase.execute({
+        docId: docId.trim(),
+      });
+
+      this.logger.log('Document content retrieved successfully', {
+        docId,
+        contentLength: result.contenido.length,
+        hasMetadata: !!result.metadata,
+      });
+
+      return new DocumentContentResponseDto(
+        result.contenido,
+        new DocumentContentMetadataDto(
+          result.metadata.paginas,
+          result.metadata.resumen,
+        ),
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      this.logger.error(
+        'Error retrieving document content',
+        error instanceof Error ? error : errorMessage,
+        {
+          docId,
+          errorType: 'DOCUMENT_CONTENT_ERROR',
+        },
+      );
+
+      // Manejar diferentes tipos de errores
+      if (errorMessage.includes('no encontrado')) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.NOT_FOUND,
+            message: 'Documento no encontrado',
+            error: 'Not Found',
+            details: errorMessage,
+          },
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (errorMessage.includes('no tiene contenido de texto extraído')) {
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: 'El documento no tiene contenido de texto extraído',
+            error: 'Bad Request',
+            details: errorMessage,
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      // Error genérico
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Error interno del servidor al obtener contenido',
+          error: 'Internal Server Error',
+          details: errorMessage,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * Extrae el tipo de archivo del mimeType para cumplir con el contrato
+   */
+  private extractFileType(mimeType: string): string {
+    if (mimeType.includes('pdf')) return 'pdf';
+    if (mimeType.includes('word')) return 'documento';
+    if (mimeType.includes('text')) return 'texto';
+    return 'documento';
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/http/dtos/associate-document-course.dto.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/dtos/associate-document-course.dto.ts
@@ -1,0 +1,34 @@
+import {
+  IsString,
+  IsOptional,
+  IsNotEmpty,
+} from 'class-validator';
+
+export class AssociateDocumentToCourseDto {
+  @IsString()
+  @IsNotEmpty()
+  documentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  courseId: string;
+}
+
+export class AssociateDocumentToCourseResponseDto {
+  success: boolean;
+  message: string;
+  documentId: string;
+  courseId: string;
+
+  constructor(
+    success: boolean,
+    message: string,
+    documentId: string,
+    courseId: string,
+  ) {
+    this.success = success;
+    this.message = message;
+    this.documentId = documentId;
+    this.courseId = courseId;
+  }
+}

--- a/backend/src/modules/repository_documents/infrastructure/http/dtos/contract-documents.dto.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/dtos/contract-documents.dto.ts
@@ -1,0 +1,120 @@
+import {
+  IsString,
+  IsNumber,
+  IsUrl,
+  IsDateString,
+  IsArray,
+  ValidateNested,
+  IsOptional,
+  IsInt,
+  Min,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+
+export class ContractDocumentItemDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  titulo: string;
+
+  @IsString()
+  tipo: string;
+
+  @IsUrl()
+  url: string;
+
+  @IsDateString()
+  fechaCarga: string;
+
+  @IsString()
+  profesorId: string;
+
+  constructor(
+    id: string,
+    titulo: string,
+    tipo: string,
+    url: string,
+    fechaCarga: Date,
+    profesorId: string,
+  ) {
+    this.id = id;
+    this.titulo = titulo;
+    this.tipo = tipo;
+    this.url = url;
+    this.fechaCarga = fechaCarga.toISOString();
+    this.profesorId = profesorId;
+  }
+}
+
+export class ContractDocumentListResponseDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ContractDocumentItemDto)
+  documentos: ContractDocumentItemDto[];
+
+  @IsNumber()
+  total: number;
+
+  @IsNumber()
+  pagina: number;
+
+  constructor(
+    documentos: ContractDocumentItemDto[],
+    total: number,
+    pagina: number,
+  ) {
+    this.documentos = documentos;
+    this.total = total;
+    this.pagina = pagina;
+  }
+}
+
+export class DocumentContentMetadataDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  paginas?: number;
+
+  @IsOptional()
+  @IsString()
+  resumen?: string;
+
+  constructor(paginas?: number, resumen?: string) {
+    this.paginas = paginas;
+    this.resumen = resumen;
+  }
+}
+
+export class DocumentContentResponseDto {
+  @IsString()
+  contenido: string;
+
+  @ValidateNested()
+  @Type(() => DocumentContentMetadataDto)
+  metadata: DocumentContentMetadataDto;
+
+  constructor(contenido: string, metadata: DocumentContentMetadataDto) {
+    this.contenido = contenido;
+    this.metadata = metadata;
+  }
+}
+
+// Query parameters DTOs
+export class GetDocumentsBySubjectQueryDto {
+  @IsOptional()
+  @IsString()
+  tipo?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Transform(({ value }) => parseInt(value))
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+}


### PR DESCRIPTION
### Implementations

This pull request introduces a new set of endpoints and supporting infrastructure to fulfill the "contract endpoints" for accessing and managing subject-specific documents in the backend. The implementation includes new database relations, use cases, controllers, and documentation for both developers and testers. The changes are grouped below by theme for clarity.

**Contract Endpoints Implementation**

- Added a new controller (`ContractDocumentsController`) and related use cases to provide endpoints for listing documents by subject and retrieving the content of a specific document, as required by the contract. These endpoints are fully documented and support authentication, filtering, and pagination. [[1]](diffhunk://#diff-c77df6de79be1ee1601d1a25d0cdd768234ae9ca5b90045e4265f0c6e6569f2aR1-R134) [[2]](diffhunk://#diff-8d24d9dbf58d9b1d5cf169f9d0b85a81acce46f635dc9e8b905de68a385f33dfR25) [[3]](diffhunk://#diff-8d24d9dbf58d9b1d5cf169f9d0b85a81acce46f635dc9e8b905de68a385f33dfR49-R58) [[4]](diffhunk://#diff-8d24d9dbf58d9b1d5cf169f9d0b85a81acce46f635dc9e8b905de68a385f33dfR219-R240) [[5]](diffhunk://#diff-8d24d9dbf58d9b1d5cf169f9d0b85a81acce46f635dc9e8b905de68a385f33dfR255-R258) [[6]](diffhunk://#diff-8d24d9dbf58d9b1d5cf169f9d0b85a81acce46f635dc9e8b905de68a385f33dfL247-R289)

**Database Schema and Migrations**

- Extended the `Document` model and database schema to support an optional relation to `Course`, including a new `courseId` field, index, and foreign key constraint with `ON DELETE SET NULL`. Also updated the `Course` model to relate to documents. [[1]](diffhunk://#diff-1140844a00f5653242367f7a8d7e30f5ff84d2e35c3d475d931cd839300093b7R1-R8) [[2]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR153-R156) [[3]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR175) [[4]](diffhunk://#diff-93ead908b5ffa6f6e995757b3739fb02b4e9f8d0ea1da0ec34a9c03c1a33f9bfR373-R375)

**Application Layer: Use Cases**

- Implemented `GetDocumentsBySubjectUseCase` for retrieving paginated, filtered lists of documents by course/subject, and `GetDocumentContentUseCase` for extracting the text content and metadata of a document. [[1]](diffhunk://#diff-bd2479f840c022a07c2b575b936261e9ea612456d48a7d75b212ffa3cb552577R1-R99) [[2]](diffhunk://#diff-29225085fa5c022322968c509c7940023a6f128b3e14198be05764f74d62c6e3R1-R60)
- Added `AssociateDocumentToCourseUseCase` to associate an existing document with a course.

**Testing and Documentation**

- Added comprehensive documentation for contract endpoints (`CONTRACT_ENDPOINTS_DOCUMENTATION.md`) and a detailed Postman testing guide (`POSTMAN_TESTING_GUIDE.md`), including example requests, expected responses, troubleshooting tips, and automation scripts. [[1]](diffhunk://#diff-c77df6de79be1ee1601d1a25d0cdd768234ae9ca5b90045e4265f0c6e6569f2aR1-R134) [[2]](diffhunk://#diff-b1dce0cb79e3691ba99a97c624f801b4bf1b914e9bf3ea39e9a1279c2ac17b37R1-R256)

These changes collectively provide a robust, contract-compliant API for managing subject-specific documents, with clear documentation and improved testability.

### For test the feature
Actually there is no data in the database to help us to achieve this. The tester has to mock some values in order to accomplish the test. You can create a test harcoded .js with axios to test the endpoint and you have to start the docker container and the backend. 

There is documentation in 2 readmes in order to accomplish the test succesfully. If everything goes right you will see this outputs: 

Obtain the documents in Algorithm I
```
GET http://localhost:3000/api/v1/documentos/materias/fe895b2f-9629-45eb-9342-7a7f95aba5e6/documentos
```
![Imagen de WhatsApp 2025-09-07 a las 00 19 13_5e3b6690](https://github.com/user-attachments/assets/be8d1bea-9eec-4fad-b887-915967eff134)

Extract the content of the book or pdf
```
GET http://localhost:3000/api/v1/documentos/cfb19a06-89f8-445d-bccd-637fead2406f/contenido

```
![Imagen de WhatsApp 2025-09-07 a las 00 19 28_2a187c8a](https://github.com/user-attachments/assets/9f6ade42-1a4b-492a-96a9-a52bc895317c)
 
List all documents
```
GET http://localhost:3000/api/documents

```
![Imagen de WhatsApp 2025-09-07 a las 00 20 42_c6c77413](https://github.com/user-attachments/assets/f07f5477-acc7-4b14-b630-0a3d3f38db43)

