### PR TITLE
feat(MD-105): combined changes (squash of last 2 commits)

### DIFF
--- a/backend/prisma/migrations/20250907221213_create_tables/migration.sql
+++ b/backend/prisma/migrations/20250907221213_create_tables/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[textHash]` on the table `Document` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Document" ADD COLUMN     "textHash" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Document_textHash_key" ON "public"."Document"("textHash");
+
+-- CreateIndex
+CREATE INDEX "Document_textHash_idx" ON "public"."Document"("textHash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -143,6 +143,7 @@ model Document {
   size         Int
   contentType  String
   fileHash         String                    @unique // Hash SHA-256 del archivo
+  textHash         String?                   @unique // Hash SHA-256 del texto normalizado
   extractedText    String?                   @db.Text // Texto extraído
   status           DocumentStatus            @default(UPLOADED)
   
@@ -171,6 +172,7 @@ model Document {
   @@index([status])
   @@index([uploadedBy])
   @@index([fileHash])
+  @@index([textHash])
   @@index([contentType])
   @@index([courseId])
 }

--- a/backend/src/modules/repository_documents/application/use-cases/check-document-similarity.usecase.ts
+++ b/backend/src/modules/repository_documents/application/use-cases/check-document-similarity.usecase.ts
@@ -1,0 +1,270 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'crypto';
+import type { DocumentRepositoryPort } from '../../domain/ports/document-repository.port';
+import type { TextExtractionPort } from '../../domain/ports/text-extraction.port';
+import type { ChunkingStrategyPort } from '../../domain/ports/chunking-strategy.port';
+import type { EmbeddingGeneratorPort } from '../../domain/ports/embedding-generator.port';
+import type { VectorSearchPort } from '../../domain/ports/vector-search.port';
+import type { DocumentChunkRepositoryPort } from '../../domain/ports/document-chunk-repository.port';
+import {
+  CheckDocumentSimilarityRequest,
+  DocumentSimilarityResult,
+  DocumentMatch,
+  SimilarDocumentCandidate,
+  DocumentScore,
+} from '../../domain/value-objects/document-similarity-check.vo';
+
+@Injectable()
+export class CheckDocumentSimilarityUseCase {
+  private readonly logger = new Logger(CheckDocumentSimilarityUseCase.name);
+
+  constructor(
+    private readonly documentRepository: DocumentRepositoryPort,
+    private readonly textExtraction: TextExtractionPort,
+    private readonly chunkingStrategy: ChunkingStrategyPort,
+    private readonly embeddingGenerator: EmbeddingGeneratorPort,
+    private readonly vectorSearch: VectorSearchPort,
+    private readonly chunkRepository: DocumentChunkRepositoryPort,
+  ) {}
+
+  async execute(
+    request: CheckDocumentSimilarityRequest,
+  ): Promise<DocumentSimilarityResult> {
+    try {
+      this.logger.log(`Starting similarity check for: ${request.originalName}`);
+
+  // paso 1: verificar hash binario exacto (sha-256)
+      const fileHash = this.generateFileHash(request.file);
+      const exactMatch = await this.documentRepository.findByFileHash(fileHash);
+
+      if (exactMatch) {
+        this.logger.log(`Found exact binary match: ${exactMatch.id}`);
+        return new DocumentSimilarityResult(
+          'exact_match',
+          new DocumentMatch(
+            exactMatch.id,
+            exactMatch.originalName,
+            exactMatch.uploadedAt,
+            exactMatch.uploadedBy,
+            'binary_hash',
+            exactMatch.documentTitle,
+            exactMatch.documentAuthor,
+          ),
+        );
+      }
+
+  // paso 2: extraer texto y verificar hash de texto
+      const extractedText = await this.textExtraction.extractTextFromPdf(
+        request.file,
+        request.originalName,
+      );
+
+      const textHash = this.generateTextHash(extractedText.content);
+
+  // verificar coincidencia por hash de texto (mismo contenido, posible otra edición)
+      const textHashMatch =
+        await this.documentRepository.findByTextHash(textHash);
+      if (textHashMatch) {
+        this.logger.log(
+          `Text hash match found for document: ${textHashMatch.id}`,
+        );
+        return new DocumentSimilarityResult(
+          'text_hash_match',
+          new DocumentMatch(
+            textHashMatch.id,
+            textHashMatch.originalName,
+            textHashMatch.uploadedAt,
+            textHashMatch.uploadedBy,
+            'text_hash',
+            textHashMatch.documentTitle,
+            textHashMatch.documentAuthor,
+          ),
+        );
+      }
+
+  // paso 3: omitir embeddings si se solicita
+      if (request.options?.skipEmbeddings) {
+        return new DocumentSimilarityResult('no_match');
+      }
+
+  // paso 4: generar chunks y embeddings para la verificación de similitud
+      const similarCandidates = await this.findSimilarDocuments(
+        extractedText.content,
+        request.options?.similarityThreshold ?? 0.8,
+        request.options?.maxCandidates ?? 10,
+        request.options?.useSampling ?? true,
+      );
+
+      if (similarCandidates.length > 0) {
+        this.logger.log(`Found ${similarCandidates.length} similar candidates`);
+        return new DocumentSimilarityResult(
+          'candidates',
+          undefined,
+          similarCandidates,
+          `Found ${similarCandidates.length} similar documents`,
+        );
+      }
+
+      this.logger.log('No similar documents found');
+      return new DocumentSimilarityResult('no_match');
+    } catch (error) {
+      this.logger.error(`Error checking document similarity: ${error.message}`);
+      throw error;
+    }
+  }
+
+  // genera hash sha-256 del contenido del archivo
+  private generateFileHash(fileBuffer: Buffer): string {
+    return createHash('sha256').update(fileBuffer).digest('hex');
+  }
+
+  // genera hash del texto normalizado
+  private generateTextHash(text: string): string {
+    // normalizar texto: minúsculas, quitar espacios extra y normalizar saltos de línea
+    const normalizedText = text
+      .toLowerCase()
+      .replace(/\s+/g, ' ')
+      .replace(/\r\n/g, '\n')
+      .trim();
+
+    return createHash('sha256').update(normalizedText, 'utf8').digest('hex');
+  }
+
+  // buscar documentos similares usando embeddings y búsqueda vectorial
+  private async findSimilarDocuments(
+    text: string,
+    threshold: number,
+    maxCandidates: number,
+    useSampling: boolean,
+  ): Promise<SimilarDocumentCandidate[]> {
+    try {
+  // paso 1: generar chunks - se usa un id temporal
+      const tempDocumentId = 'temp-similarity-check';
+      const defaultConfig = this.chunkingStrategy.getDefaultConfig();
+
+      const chunkingResult = await this.chunkingStrategy.chunkText(
+        tempDocumentId,
+        text,
+        {
+          ...defaultConfig,
+          maxChunkSize: 1000,
+          overlap: 200,
+        },
+      );
+
+  // paso 2: muestrear chunks si se solicita (procesamiento más rápido)
+      const chunksToProcess = useSampling
+        ? this.sampleChunks(chunkingResult.chunks, 20)
+        : chunkingResult.chunks;
+
+      this.logger.log(
+        `Processing ${chunksToProcess.length} chunks (sampling: ${useSampling})`,
+      );
+
+  // paso 3: generar embeddings para los chunks
+      const chunkContents = chunksToProcess.map(
+        (chunk: any) => chunk.content as string,
+      );
+      const embeddingResult =
+        await this.embeddingGenerator.generateBatchEmbeddings(chunkContents);
+
+  // paso 4: buscar chunks similares
+      const documentScores = new Map<string, DocumentScore>();
+
+      for (let i = 0; i < embeddingResult.embeddings.length; i++) {
+        const embedding = embeddingResult.embeddings[i];
+        const searchResults = await this.vectorSearch.searchByVector(
+          embedding,
+          {
+            limit: 5, // 5 mejores coincidencias por chunk
+            similarityThreshold: Math.max(0.3, threshold - 0.2), // más permisivo para chunks individuales
+          },
+        );
+
+  // agregar resultados por documento
+        for (const result of searchResults.chunks) {
+          const docId = result.documentId;
+          if (!documentScores.has(docId)) {
+            documentScores.set(docId, {
+              documentId: docId,
+              similarities: [],
+              matchedChunks: 0,
+              totalChunks: chunksToProcess.length,
+              avgSimilarity: 0,
+              coverage: 0,
+              finalScore: 0,
+            });
+          }
+
+          const docScore = documentScores.get(docId)!;
+          docScore.similarities.push(result.similarityScore);
+          docScore.matchedChunks++;
+        }
+      }
+
+  // paso 5: calcular puntuaciones finales y filtrar candidatos
+      const candidates: SimilarDocumentCandidate[] = [];
+
+      for (const [documentId, score] of documentScores) {
+  // calcular métricas
+        score.avgSimilarity =
+          score.similarities.reduce((sum, sim) => sum + sim, 0) /
+          score.similarities.length;
+        score.coverage = score.matchedChunks / score.totalChunks;
+        score.finalScore = 0.7 * score.avgSimilarity + 0.3 * score.coverage;
+
+  // filtrar por umbral
+        if (score.finalScore >= threshold) {
+          // obtener detalles del documento
+          const document = await this.documentRepository.findById(documentId);
+          if (document) {
+            candidates.push(
+              new SimilarDocumentCandidate(
+                document.id,
+                document.originalName,
+                document.uploadedAt,
+                document.uploadedBy,
+                score.finalScore,
+                score.avgSimilarity,
+                score.coverage,
+                score.matchedChunks,
+                score.totalChunks,
+                document.documentTitle,
+                document.documentAuthor,
+              ),
+            );
+          }
+        }
+      }
+
+  // ordenar por puntuación (mayor primero) y limitar resultados
+      return candidates
+        .sort((a, b) => b.similarityScore - a.similarityScore)
+        .slice(0, maxCandidates);
+    } catch (error) {
+      this.logger.error(
+        `Error finding similar documents: ${(error as Error).message}`,
+      );
+      throw error;
+    }
+  }
+
+  // muestrea chunks para procesamiento más rápido
+  // toma chunks del inicio, medio y final del documento
+  private sampleChunks(chunks: any[], maxSamples: number): any[] {
+    if (chunks.length <= maxSamples) {
+      return chunks;
+    }
+
+    const sampled: any[] = [];
+    const step = chunks.length / maxSamples;
+
+  // tomar muestras distribuidas a lo largo del documento
+    for (let i = 0; i < maxSamples; i++) {
+      const index = Math.floor(i * step);
+      sampled.push(chunks[index]);
+    }
+
+    return sampled;
+  }
+}

--- a/backend/src/modules/repository_documents/domain/entities/document.entity.ts
+++ b/backend/src/modules/repository_documents/domain/entities/document.entity.ts
@@ -11,6 +11,7 @@ export class Document {
     public readonly uploadedBy: string,
     public readonly status: DocumentStatus = DocumentStatus.UPLOADED,
     public readonly extractedText?: string,
+    public readonly textHash?: string,
     public readonly pageCount?: number,
     public readonly documentTitle?: string,
     public readonly documentAuthor?: string,
@@ -49,6 +50,7 @@ export class Document {
    */
   withExtractedText(
     extractedText: string,
+    textHash?: string,
     pageCount?: number,
     documentTitle?: string,
     documentAuthor?: string,
@@ -66,6 +68,7 @@ export class Document {
       this.uploadedBy,
       this.status,
       extractedText,
+      textHash,
       pageCount,
       documentTitle,
       documentAuthor,
@@ -91,6 +94,33 @@ export class Document {
       this.uploadedBy,
       status,
       this.extractedText,
+      this.textHash,
+      this.pageCount,
+      this.documentTitle,
+      this.documentAuthor,
+      this.language,
+      this.uploadedAt,
+      new Date(),
+    );
+  }
+
+  /**
+   * Actualiza el hash del texto del documento
+   */
+  withTextHash(textHash: string): Document {
+    return new Document(
+      this.id,
+      this.fileName,
+      this.originalName,
+      this.mimeType,
+      this.size,
+      this.url,
+      this.s3Key,
+      this.fileHash,
+      this.uploadedBy,
+      this.status,
+      this.extractedText,
+      textHash,
       this.pageCount,
       this.documentTitle,
       this.documentAuthor,

--- a/backend/src/modules/repository_documents/domain/ports/document-repository.port.ts
+++ b/backend/src/modules/repository_documents/domain/ports/document-repository.port.ts
@@ -23,6 +23,13 @@ export interface DocumentRepositoryPort {
   findByFileHash(fileHash: string): Promise<Document | undefined>;
 
   /**
+   * Busca un documento por su hash de texto normalizado
+   * @param textHash Hash SHA-256 del texto normalizado
+   * @returns Documento encontrado o undefined
+   */
+  findByTextHash(textHash: string): Promise<Document | undefined>;
+
+  /**
    * Busca un documento por clave S3
    * @param s3Key Clave del archivo en S3
    * @returns Documento encontrado o undefined

--- a/backend/src/modules/repository_documents/domain/value-objects/document-similarity-check.vo.ts
+++ b/backend/src/modules/repository_documents/domain/value-objects/document-similarity-check.vo.ts
@@ -1,0 +1,85 @@
+/**
+ * Result of checking document similarity
+ */
+export class DocumentSimilarityResult {
+  constructor(
+    public readonly status:
+      | 'exact_match'
+      | 'text_hash_match'
+      | 'text_match'
+      | 'candidates'
+      | 'no_match',
+    public readonly existingDocument?: DocumentMatch,
+    public readonly similarCandidates?: SimilarDocumentCandidate[],
+    public readonly message?: string,
+  ) {}
+}
+
+/**
+ * Document that matches exactly or by text
+ */
+export class DocumentMatch {
+  constructor(
+    public readonly id: string,
+    public readonly originalName: string,
+    public readonly uploadedAt: Date,
+    public readonly uploadedBy: string,
+    public readonly matchType: 'binary_hash' | 'text_hash',
+    public readonly documentTitle?: string,
+    public readonly documentAuthor?: string,
+  ) {}
+}
+
+/**
+ * Similar document candidate found by embeddings
+ */
+export class SimilarDocumentCandidate {
+  constructor(
+    public readonly id: string,
+    public readonly originalName: string,
+    public readonly uploadedAt: Date,
+    public readonly uploadedBy: string,
+    public readonly similarityScore: number,
+    public readonly avgSimilarity: number,
+    public readonly coverage: number,
+    public readonly matchedChunks: number,
+    public readonly totalChunks: number,
+    public readonly documentTitle?: string,
+    public readonly documentAuthor?: string,
+  ) {}
+}
+
+/**
+ * Request to check document similarity
+ */
+export class CheckDocumentSimilarityRequest {
+  constructor(
+    public readonly file: Buffer,
+    public readonly originalName: string,
+    public readonly mimeType: string,
+    public readonly uploadedBy: string,
+    public readonly options?: {
+      /** Only check exact/text hash, skip embeddings */
+      skipEmbeddings?: boolean;
+      /** Minimum similarity threshold for candidates */
+      similarityThreshold?: number;
+      /** Maximum number of candidates to return */
+      maxCandidates?: number;
+      /** Use sampling for faster check */
+      useSampling?: boolean;
+    },
+  ) {}
+}
+
+/**
+ * Internal scoring result for aggregating chunk matches by document
+ */
+export interface DocumentScore {
+  documentId: string;
+  similarities: number[];
+  matchedChunks: number;
+  totalChunks: number;
+  avgSimilarity: number;
+  coverage: number;
+  finalScore: number;
+}

--- a/backend/src/modules/repository_documents/infrastructure/http/dtos/check-document-similarity.dto.ts
+++ b/backend/src/modules/repository_documents/infrastructure/http/dtos/check-document-similarity.dto.ts
@@ -1,0 +1,87 @@
+/**
+ * Response DTO for document similarity check
+ */
+export class CheckDocumentSimilarityResponseDto {
+  constructor(
+    public readonly status: 'exact_match' | 'text_hash_match' | 'text_match' | 'candidates' | 'no_match',
+    public readonly message: string,
+    public readonly existingDocument?: ExistingDocumentDto,
+    public readonly similarCandidates?: SimilarDocumentDto[],
+  ) {}
+}
+
+/**
+ * DTO for existing document that matches
+ */
+export class ExistingDocumentDto {
+  constructor(
+    public readonly id: string,
+    public readonly originalName: string,
+    public readonly documentTitle: string | null,
+    public readonly documentAuthor: string | null,
+    public readonly uploadedAt: Date,
+    public readonly uploadedBy: string,
+    public readonly matchType: 'binary_hash' | 'text_hash',
+  ) {}
+}
+
+/**
+ * DTO for similar document candidate
+ */
+export class SimilarDocumentDto {
+  constructor(
+    public readonly id: string,
+    public readonly originalName: string,
+    public readonly documentTitle: string | null,
+    public readonly documentAuthor: string | null,
+    public readonly uploadedAt: Date,
+    public readonly uploadedBy: string,
+    public readonly similarityScore: number,
+    public readonly details: {
+      avgSimilarity: number;
+      coverage: number;
+      matchedChunks: number;
+      totalChunks: number;
+    },
+  ) {}
+}
+
+/**
+ * Request DTO for document similarity check
+ */
+export class CheckDocumentSimilarityRequestDto {
+  constructor(
+    public readonly skipEmbeddings?: boolean,
+    public readonly similarityThreshold?: number,
+    public readonly maxCandidates?: number,
+    public readonly useSampling?: boolean,
+  ) {}
+}
+
+/**
+ * Response DTO for upload with confirmation required
+ */
+export class UploadWithConfirmationResponseDto {
+  constructor(
+    public readonly status: 'confirm_required',
+    public readonly message: string,
+    public readonly fileHash: string,
+    public readonly similarDocuments: SimilarDocumentDto[],
+    public readonly uploadData: {
+      originalName: string;
+      size: number;
+      mimeType: string;
+    },
+  ) {}
+}
+
+/**
+ * Request DTO for confirming upload
+ */
+export class ConfirmUploadRequestDto {
+  constructor(
+    public readonly fileHash: string,
+    public readonly forceSave: boolean,
+    public readonly userId: string,
+  ) {}
+}

--- a/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-repository.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/persistence/prisma-document-repository.adapter.ts
@@ -23,6 +23,7 @@ export class PrismaDocumentRepositoryAdapter implements DocumentRepositoryPort {
           size: document.size,
           contentType: document.mimeType,
           fileHash: document.fileHash,
+          textHash: document.textHash,
           extractedText: document.extractedText,
           status: document.status as any,
           uploadedBy: document.uploadedBy,
@@ -67,6 +68,21 @@ export class PrismaDocumentRepositoryAdapter implements DocumentRepositoryPort {
         `Error finding document by hash ${fileHash}: ${error.message}`,
       );
       throw new Error(`Failed to find document by hash: ${error.message}`);
+    }
+  }
+
+  async findByTextHash(textHash: string): Promise<Document | undefined> {
+    try {
+      const document = await this.prisma.document.findUnique({
+        where: { textHash },
+      });
+
+      return document ? this.mapToDomain(document) : undefined;
+    } catch (error) {
+      this.logger.error(
+        `Error finding document by text hash ${textHash}: ${error.message}`,
+      );
+      throw new Error(`Failed to find document by text hash: ${error.message}`);
     }
   }
 
@@ -249,6 +265,7 @@ export class PrismaDocumentRepositoryAdapter implements DocumentRepositoryPort {
       prismaDocument.language,
       prismaDocument.uploadedAt,
       prismaDocument.updatedAt,
+      prismaDocument.textHash,
     );
   }
 

--- a/backend/src/modules/repository_documents/infrastructure/search/pgvector-search.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/search/pgvector-search.adapter.ts
@@ -9,7 +9,7 @@ import type {
 import type { EmbeddingGeneratorPort } from '../../domain/ports/embedding-generator.port';
 
 /**
- * Opciones de configuración para pgvector
+ * opciones de configuración para pgvector
  */
 export interface PgVectorConfig {
   /** Función de distancia a utilizar */
@@ -29,10 +29,9 @@ export interface PgVectorConfig {
 }
 
 /**
- * Adaptador para búsqueda vectorial usando pgvector
+ * adaptador para búsqueda vectorial usando pgvector
  *
- * Implementa búsquedas por similaridad semántica utilizando
- * la extensión pgvector de PostgreSQL
+ * implementa búsquedas por similaridad semántica con pgvector
  */
 export class PgVectorSearchAdapter implements VectorSearchPort {
   constructor(
@@ -44,90 +43,108 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   ) {}
 
   /**
-   * Busca chunks similares usando un vector de embedding
+   * busca chunks similares usando un vector de embedding
    */
   async searchByVector(
     queryVector: number[],
     options: VectorSearchOptions = {},
   ): Promise<VectorSearchResult> {
     try {
-      // 1. Validar entrada
+      // validar entrada
       this.validateVector(queryVector);
       const finalOptions = this.normalizeOptions(options);
 
-      // 2. Construir consulta SQL
-      const distanceOperator = this.getDistanceOperator();
-      const orderDirection = this.getOrderDirection();
-
-      // 3. Construir filtros WHERE
-      const whereConditions = this.buildWhereConditions(finalOptions);
-      const whereClause =
-        whereConditions.length > 0
-          ? `WHERE ${whereConditions.join(' AND ')}`
-          : '';
-
-      // 4. Ejecutar consulta
-      const query = `
-        SELECT 
-          dc.id,
-          dc.document_id,
-          dc.chunk_index,
-          dc.content,
-          dc.type,
-          dc.word_count,
-          dc.char_count,
-          dc.start_position,
-          dc.end_position,
-          dc.metadata,
-          dc.created_at,
-          d.title as document_title,
-          d.file_name as document_file_name,
-          d.file_size as document_file_size,
-          d.content_type as document_content_type,
-          (dc.embedding ${distanceOperator} $1::vector) as similarity_score
-        FROM document_chunks dc
-        INNER JOIN documents d ON dc.document_id = d.id
-        ${whereClause}
-        ${
-          finalOptions.similarityThreshold
-            ? `AND (dc.embedding ${distanceOperator} $1::vector) ${this.getThresholdOperator()} $${whereConditions.length + 2}`
-            : ''
-        }
-        ORDER BY dc.embedding ${distanceOperator} $1::vector ${orderDirection}
-        LIMIT $${finalOptions.similarityThreshold ? whereConditions.length + 3 : whereConditions.length + 2}
-      `;
-
-      // 5. Preparar parámetros
-      const params: any[] = [JSON.stringify(queryVector)];
-      // Agregar parámetros de filtros WHERE aquí si los hay
+      // construir consulta según si hay umbral o no
+      let query: string;
+      let params: any[];
 
       if (finalOptions.similarityThreshold) {
-        params.push(finalOptions.similarityThreshold);
+        query = `
+          SELECT 
+            dc.id,
+            dc."documentId",
+            dc."chunkIndex",
+            dc.content,
+            dc.type,
+            dc."wordCount",
+            dc."charCount",
+            dc."startPosition",
+            dc."endPosition",
+            dc.metadata,
+            dc."createdAt",
+            d."documentTitle" as document_title,
+            d."originalName" as document_file_name,
+            d.size as document_file_size,
+            d."contentType" as document_content_type,
+            (1 - (dc.embedding <=> $1::vector)) as similarity_score
+          FROM document_chunks dc
+          INNER JOIN "Document" d ON dc."documentId" = d.id
+          WHERE dc.embedding IS NOT NULL
+          AND (1 - (dc.embedding <=> $1::vector)) >= $2
+          ORDER BY dc.embedding <=> $1::vector ASC
+          LIMIT $3
+        `;
+        params = [
+          `[${queryVector.join(',')}]`,
+          finalOptions.similarityThreshold,
+          finalOptions.limit,
+        ];
+      } else {
+        query = `
+          SELECT 
+            dc.id,
+            dc."documentId",
+            dc."chunkIndex",
+            dc.content,
+            dc.type,
+            dc."wordCount",
+            dc."charCount",
+            dc."startPosition",
+            dc."endPosition",
+            dc.metadata,
+            dc."createdAt",
+            d."documentTitle" as document_title,
+            d."originalName" as document_file_name,
+            d.size as document_file_size,
+            d."contentType" as document_content_type,
+            (1 - (dc.embedding <=> $1::vector)) as similarity_score
+          FROM document_chunks dc
+          INNER JOIN "Document" d ON dc."documentId" = d.id
+          WHERE dc.embedding IS NOT NULL
+          ORDER BY dc.embedding <=> $1::vector ASC
+          LIMIT $2
+        `;
+        params = [`[${queryVector.join(',')}]`, finalOptions.limit];
       }
-      params.push(finalOptions.limit);
 
-      // 6. Ejecutar consulta (por ahora simulada)
-      // En implementación real: const results = await this.prisma.$queryRawUnsafe(query, ...params);
-      console.log('🔍 Ejecutando búsqueda vectorial:', {
-        vectorDimensions: queryVector.length,
-        options: finalOptions,
-        query:
-          typeof query === 'string'
-            ? query.replace(/\s+/g, ' ').trim()
-            : 'vector search',
-      });
+      // ejecutar consulta de búsqueda vectorial
+      const results = await this.prisma.$queryRawUnsafe(query, ...params);
 
-      // Simular resultados por ahora
-      const results = await this.simulateVectorSearch(
-        queryVector,
-        finalOptions,
-      );
+      // mapear resultados a la interfaz esperada
+      const mappedResults = (results as any[]).map((row) => ({
+        id: row.id,
+        documentId: row.documentId,
+        content: row.content,
+        type: row.type,
+        chunkIndex: row.chunkIndex,
+        wordCount: row.wordCount,
+        charCount: row.charCount,
+        startPosition: row.startPosition,
+        endPosition: row.endPosition,
+        similarityScore: parseFloat(row.similarity_score),
+        documentTitle: row.document_title,
+        documentFileName: row.document_file_name,
+        documentFileSize: row.document_file_size,
+        documentContentType: row.document_content_type,
+        metadata: row.metadata,
+        createdAt: row.createdAt,
+      }));
 
       return {
-        chunks: results,
-        totalResults: results.length,
+        chunks: mappedResults,
+        totalResults: mappedResults.length,
         searchOptions: finalOptions,
-        processingTimeMs: 0, // Calcular tiempo real
+        processingTimeMs: 0, // calcular tiempo real
       };
     } catch (error) {
       console.error('❌ Error en búsqueda vectorial:', error);
@@ -136,14 +153,14 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   }
 
   /**
-   * Busca chunks similares convirtiendo texto a vector primero
+   * busca chunks similares convirtiendo texto a vector primero
    */
   async searchByText(
     query: string,
     options: VectorSearchOptions = {},
   ): Promise<SemanticSearchResult> {
     try {
-      // Validar entrada
+      // validar entrada
       if (!query || typeof query !== 'string') {
         throw new Error('El query de búsqueda debe ser una cadena válida');
       }
@@ -153,11 +170,11 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
         throw new Error('El query de búsqueda no puede estar vacío');
       }
 
-      // 1. Generar embedding del texto de consulta
+      // 1. generar embedding del texto de consulta
       const embeddingResult =
         await this.embeddingGenerator.generateEmbedding(trimmedQuery);
 
-      // 2. Buscar usando el vector
+      // 2. buscar usando el vector
       const vectorResult = await this.searchByVector(
         embeddingResult.embedding,
         options,
@@ -171,26 +188,26 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
         processingTimeMs: vectorResult.processingTimeMs,
       };
     } catch (error) {
-      console.error('❌ Error en búsqueda por texto:', error);
+      console.error('Error en búsqueda por texto:', error);
       throw this.handleSearchError(error, 'searchByText');
     }
   }
 
   /**
-   * Encuentra chunks similares a uno específico
+   * encuentra chunks similares a uno específico
    */
   async findSimilarChunks(
     chunkId: string,
     options: VectorSearchOptions = {},
   ): Promise<VectorSearchResult> {
     try {
-      // 1. Obtener el chunk de referencia
+      // 1. obtener el chunk de referencia
       const referenceChunk = await this.getChunkEmbedding(chunkId);
       if (!referenceChunk) {
         throw new Error(`No se encontró el chunk con ID: ${chunkId}`);
       }
 
-      // 2. Buscar chunks similares excluyendo el mismo
+      // 2. buscar chunks similares excluyendo el mismo
       const finalOptions = {
         ...options,
         excludeChunkIds: [...(options.excludeChunkIds || []), chunkId],
@@ -198,20 +215,20 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
 
       return this.searchByVector(referenceChunk.embedding, finalOptions);
     } catch (error) {
-      console.error('❌ Error encontrando chunks similares:', error);
+      console.error('Error encontrando chunks similares:', error);
       throw this.handleSearchError(error, 'findSimilarChunks');
     }
   }
 
   /**
-   * Encuentra documentos similares a uno específico
+   * encuentra documentos similares a uno específico
    */
   async findSimilarDocuments(
     documentId: string,
     options: VectorSearchOptions = {},
   ): Promise<SimilarDocument[]> {
     try {
-      // 1. Obtener embeddings promedio del documento
+      // 1. obtener embeddings promedio del documento
       const documentEmbedding =
         await this.getDocumentAverageEmbedding(documentId);
       if (!documentEmbedding) {
@@ -220,7 +237,7 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
         );
       }
 
-      // 2. Buscar documentos similares
+      // 2. buscar documentos similares
       const finalOptions = {
         ...options,
         excludeDocumentIds: [...(options.excludeDocumentIds || []), documentId],
@@ -232,7 +249,7 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
         finalOptions,
       );
 
-      // 3. Agrupar por documento y calcular similaridad promedio
+      // 3. agrupar por documento y calcular similaridad promedio
       const documentMap = new Map<
         string,
         {
@@ -261,7 +278,7 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
         );
       });
 
-      // 4. Convertir a SimilarDocument[]
+      // 4. convertir a similardocument[]
       const similarDocuments: SimilarDocument[] = [];
       for (const [docId, data] of documentMap) {
         const firstChunk = data.chunks[0];
@@ -271,27 +288,27 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
           fileName: firstChunk.documentFileName,
           averageSimilarity: data.totalSimilarity / data.chunks.length,
           maxSimilarity: data.maxSimilarity,
-          relevantChunks: data.chunks.slice(0, 3), // Top 3 chunks más relevantes
+          relevantChunks: data.chunks.slice(0, 3), // 3 chunks más relevantes
           totalChunks: data.chunks.length,
         });
       }
 
-      // 5. Ordenar por similaridad promedio
+      // 5. ordenar por similaridad promedio
       similarDocuments.sort(
         (a, b) => b.averageSimilarity - a.averageSimilarity,
       );
 
       return similarDocuments.slice(0, options.limit || 10);
     } catch (error) {
-      console.error('❌ Error encontrando documentos similares:', error);
+      console.error('Error encontrando documentos similares:', error);
       throw this.handleSearchError(error, 'findSimilarDocuments');
     }
   }
 
-  // ============ MÉTODOS PRIVADOS ============
+  // ============ métodos privados ============
 
   /**
-   * Valida que el vector sea válido
+   * valida que el vector sea válido
    */
   private validateVector(vector: number[]): void {
     if (!Array.isArray(vector) || vector.length === 0) {
@@ -304,14 +321,14 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
       );
     }
 
-    // Verificar dimensiones típicas
+    // verificar dimensiones típicas
     if (![256, 512, 1024, 1536, 3072].includes(vector.length)) {
       console.warn(`⚠️ Dimensiones inusuales del vector: ${vector.length}`);
     }
   }
 
   /**
-   * Normaliza las opciones de búsqueda
+   * normaliza las opciones de búsqueda
    */
   private normalizeOptions(
     options: VectorSearchOptions,
@@ -331,7 +348,7 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   }
 
   /**
-   * Obtiene el operador de distancia SQL según la configuración
+   * valida que el vector de entrada sea válido
    */
   private getDistanceOperator(): string {
     switch (this.config.distanceFunction) {
@@ -347,21 +364,21 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   }
 
   /**
-   * Obtiene la dirección de ordenamiento
+   * obtiene la dirección de ordenamiento
    */
   private getOrderDirection(): string {
     return this.config.distanceFunction === 'inner_product' ? 'DESC' : 'ASC';
   }
 
   /**
-   * Obtiene el operador de umbral
+   * obtiene el operador de umbral
    */
   private getThresholdOperator(): string {
     return this.config.distanceFunction === 'inner_product' ? '>=' : '<=';
   }
 
   /**
-   * Construye condiciones WHERE para filtros
+   * construye condiciones where para filtros
    */
   private buildWhereConditions(
     options: Required<VectorSearchOptions>,
@@ -391,12 +408,12 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   }
 
   /**
-   * Obtiene el embedding de un chunk específico
+   * obtiene el embedding de un chunk específico
    */
   private async getChunkEmbedding(
     chunkId: string,
   ): Promise<{ embedding: number[] } | null> {
-    // Por ahora simulado - en implementación real:
+    // por ahora simulado - en implementación real:
     // const result = await this.prisma.documentChunk.findUnique({
     //   where: { id: chunkId },
     //   select: { embedding: true }
@@ -408,29 +425,29 @@ export class PgVectorSearchAdapter implements VectorSearchPort {
   }
 
   /**
-   * Calcula el embedding promedio de un documento
+   * calcula el embedding promedio de un documento
    */
   private async getDocumentAverageEmbedding(
     documentId: string,
   ): Promise<number[] | null> {
-    // Implementación real pendiente
+    // implementación real pendiente
     console.log('🔍 Calculando embedding promedio para documento:', documentId);
     return null; // Simular por ahora
   }
 
   /**
-   * Simula resultados de búsqueda vectorial para desarrollo
+   * simula resultados de búsqueda vectorial para desarrollo
    */
   private async simulateVectorSearch(
     queryVector: number[],
     options: Required<VectorSearchOptions>,
   ): Promise<any[]> {
-    // Simulación para desarrollo - reemplazar con consulta real
+    // simulación para desarrollo - reemplazar con consulta real
     return [];
   }
 
   /**
-   * Maneja errores de búsqueda
+   * maneja errores de búsqueda
    */
   private handleSearchError(error: unknown, operation: string): Error {
     if (error instanceof Error) {

--- a/client/src/components/shared/UploadButton.tsx
+++ b/client/src/components/shared/UploadButton.tsx
@@ -551,8 +551,8 @@ const UploadButton: React.FC<UploadButtonProps> = ({
                   icon={<PlusOutlined />}
                   onClick={handleManualSelect}
                   style={{
-                    backgroundColor: 'var(--ant-color-primary)',
-                    borderColor: 'var(--ant-color-primary)',
+                    backgroundColor: isDark ? token.colorPrimary : '#1890ff',
+                    borderColor: isDark ? token.colorPrimary : '#1890ff',
                     borderRadius: '6px',
                     fontWeight: '500'
                   }}
@@ -568,7 +568,7 @@ const UploadButton: React.FC<UploadButtonProps> = ({
               padding: isSmallScreen ? '30px 16px' : '40px 20px',
               backgroundColor: isDark ? token.colorBgElevated : '#f6ffed',
               borderRadius: '8px',
-              border: `2px solid ${isDark ? token.colorSuccess : 'var(--ant-color-success)'}`
+              border: `2px solid ${isDark ? token.colorSuccess : '#52c41a'}`
             }}>
               <CheckCircleOutlined style={{ 
                 fontSize: isSmallScreen ? '48px' : '64px', 
@@ -602,8 +602,8 @@ const UploadButton: React.FC<UploadButtonProps> = ({
                 type="primary"
                 onClick={handleCloseModal}
                 style={{
-                  backgroundColor: isDark ? token.colorSuccess : 'var(--ant-color-success)',
-                  borderColor: isDark ? token.colorSuccess : 'var(--ant-color-success)',
+                  backgroundColor: isDark ? token.colorSuccess : '#52c41a',
+                  borderColor: isDark ? token.colorSuccess : '#52c41a',
                   marginTop: '16px'
                 }}
                 size={isSmallScreen ? "middle" : "large"}

--- a/client/src/layouts/AppLayout.tsx
+++ b/client/src/layouts/AppLayout.tsx
@@ -26,9 +26,9 @@ function buildNavItems(roles: string[] | undefined): NavItem[] {
   const common: NavItem[] = [
     { key: "/", icon: <HomeOutlined />, label: <Link to="/">Home</Link> },
     {
-      key: "/upload-pdf",
+      key: "/document",
       icon: <CloudUploadOutlined />,
-      label: <Link to="/upload-pdf">Documentos</Link>,
+      label: <Link to="/document">Documentos</Link>,
     },
     {
       key: "/settings",
@@ -44,12 +44,12 @@ function buildNavItems(roles: string[] | undefined): NavItem[] {
     {
       key: "/courses",
       icon: <SolutionOutlined />,
-      label: <Link to="/courses">Materias</Link>,
+      label: <Link to="/professor/courses">Materias</Link>,
     },
     {
       key: "/exams/create",
       icon: <FileAddOutlined />,
-      label: <Link to="/exams/create">Crear Examen</Link>,
+      label: <Link to="/professor/exams/create">Crear Examen</Link>,
     },
   ];
 
@@ -57,7 +57,7 @@ function buildNavItems(roles: string[] | undefined): NavItem[] {
     {
       key: "/classes",
       icon: <BookOutlined />,
-      label: <Link to="/classes">Clases</Link>,
+      label: <Link to="/studentclasses">Clases</Link>,
     },
   ];
 

--- a/client/src/routes/routes.tsx
+++ b/client/src/routes/routes.tsx
@@ -34,24 +34,24 @@ export const AppRoutes = () => {
             <Route path="settings" element={<SettingsPage />} />
 
             {/* Professor */}
-            <Route element={<RoleRoute allowed={["docente"]} />}> 
-              <Route path="/courses" element={<TeacherCoursePage />} />
-              <Route path="/courses/:courseId/periods" element={<CoursePeriodsPage />} />
-              <Route path="/exams/create" element={<ExamsCreatePage />} />
-              <Route path="/exams" element={<ExamManagementPage />} />
-              <Route path="/classes/:id/students" element={<StudentsByClass />} />
-              <Route path="/classes/:id" element={<CourseDetailPage />} />
+            <Route path = "/professor"element={<RoleRoute allowed={["docente"]} />}> 
+              <Route path="courses" element={<TeacherCoursePage />} />
+              <Route path="courses/:courseId/periods" element={<CoursePeriodsPage />} />
+              <Route path="exams/create" element={<ExamsCreatePage />} />
+              <Route path="exams" element={<ExamManagementPage />} />
+              <Route path="classes/:id/students" element={<StudentsByClass />} />
+              <Route path="classes/:id" element={<CourseDetailPage />} />
             </Route>
 
             {/* Students */}
-            <Route element={<RoleRoute allowed={["estudiante"]} />}> 
-              <Route path="/classes" element={<ClassMenu />} />
-              <Route path="/reinforcement" element={<Reinforcement />} />
-              <Route path="/exam" element={<Exam />} />
-              <Route path="/interview" element={<Interview />} />
+            <Route path = "/student" element={<RoleRoute allowed={["estudiante"]} />}> 
+              <Route path="classes" element={<ClassMenu />} />
+              <Route path="reinforcement" element={<Reinforcement />} />
+              <Route path="exam" element={<Exam />} />
+              <Route path="interview" element={<Interview />} />
             </Route>
 
-            <Route path="/upload-pdf" element={<UploadDocumentPage />} />
+            <Route path="/document" element={<UploadDocumentPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>
         </Route>


### PR DESCRIPTION
### Descripción
Añade un flujo de verificación de similitud de documentos y endpoints auxiliares para manejar decisiones antes de subir un PDF. Esta PR introduce toda la lógica relacionada con la comprobación de similitud, confirmación de subida y controles previos al almacenamiento.

### Objetivos
Detectar documentos duplicados o con similitud de contenido antes de completar la subida.
Exponer un endpoint independiente para verificar similitud sin subir (/api/documents/check-similarity).

### Cambios:

- Nuevo endpoint: `POST /api/documents/check-similarity` (verifica similitud sin subir).
- Nuevo endpoint: `POST /api/documents/upload-with-check` (devuelve `confirm_required` y `fileHash` cuando hay candidatos similares).
- Nuevo endpoint (placeholder): `POST /api/documents/confirm-upload` (requiere almacenamiento temporal para completarse).
- Mapeo y DTOs para resultados de similitud: incluye métricas por candidato (`avgSimilarity`, `coverage`, `matchedChunks`, `totalChunks`).

### Como probar:

1) Comprobar similitud sin subir:

```powershell
curl -X POST "http://localhost:3000/api/documents/check-similarity" `
  -H "Authorization: Bearer <TOKEN>" `
  -F "file=@C:\path\to\sample.pdf" `
  -F "similarityThreshold=0.8" `
  -F "maxCandidates=5"
```

2) Subida con verificación (devuelve `confirm_required` si hay candidatos):

```powershell
curl -X POST "http://localhost:3000/api/documents/upload-with-check" `
  -H "Authorization: Bearer <TOKEN>" `
  -F "file=@C:\path\to\sample.pdf"

<img width="1370" height="381" alt="image" src="https://github.com/user-attachments/assets/2371ba56-b37f-4f16-8991-5dea486702fb" />
