### PR TITLE
Fix/[MD-139]/largeFilesErrorUpload

### DIFF
--- a/backend/src/modules/repository_documents/infrastructure/ai/openai-embedding.adapter.ts
+++ b/backend/src/modules/repository_documents/infrastructure/ai/openai-embedding.adapter.ts
@@ -427,7 +427,7 @@ export class OpenAIEmbeddingAdapter implements EmbeddingGeneratorPort {
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
       } catch (error) {
-        console.error(`❌ Error en lote ${i + 1}:`, error);
+        console.error(`Error en lote ${i + 1}:`, error);
         failedCount += batch.length;
         errors.push(
           `Lote ${i + 1}: ${error instanceof Error ? error.message : String(error)}`,
@@ -510,7 +510,7 @@ export class OpenAIEmbeddingAdapter implements EmbeddingGeneratorPort {
           await new Promise((resolve) => setTimeout(resolve, 200));
         }
       } catch (error) {
-        console.error(`❌ Error en lote ${i + 1}:`, error);
+        console.error(`Error en lote ${i + 1}:`, error);
         failedCount += batch.length;
         errors.push(
           `Lote ${i + 1}: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Descripción del Problema
Los usuarios no podían subir documentos grandes debido a que se excedían los límites de la API de OpenAI:
- **Límite de inputs**: Máximo 2,048 textos por lote
- **Límite de tokens**: Máximo 300,000 tokens por petición

## Cambios Realizados

### 1. Detección Automática de Límites
- Se implementó estimación de tokens (1 token ≈ 4 caracteres)
- Límite conservador de 250,000 tokens por petición
- Verificación de cantidad máxima de textos por lote (2,048)

### 2. Procesamiento en Lotes Inteligente
- **Por cantidad**: Divide automáticamente en lotes de máximo 2,048 textos
- **Por tokens**: Divide respetando el límite de tokens por petición
- Pausas entre lotes para evitar rate limiting

### 3. Mejoras en el Manejo de Errores
- Logging detallado del proceso de generación de embeddings
- Manejo de errores por lote individual
- Informe consolidado de resultados

## Cómo Probar

1. **Caso de prueba 1 - Documento pequeño**
   - Subir un documento de menos de 2,048 textos y verificar que se procesa en un solo lote

2. **Caso de prueba 2 - Documento grande**
   - Subir un documento grande (más de 2,048 textos o 250,000 tokens)
   - Verificar en los logs que se divide en múltiples lotes
   - Confirmar que todos los chunks se procesan correctamente

3. **Caso de prueba 3 - Límite de tokens**
   - Subir un documento con textos muy largos que superen el límite de tokens
   - Verificar que se divide correctamente respetando los límites

## Resultados Esperados
- Los documentos grandes se procesan correctamente
- No más errores de límites de OpenAI
- Mejor experiencia de usuario al subir documentos