### PR TITLE
Fix[MD-84]: Refactor the use of meAPI to get user ID from context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { useThemeStore } from "./store/themeStore";
 import "./App.css";
 import { useUserStore } from "./store/userStore";
 import { ThemedVars } from "./ThemedVars";
+import { UserProvider } from "./context/UserContext";
 
 function App() {
   const theme = useThemeStore((s) => s.theme);
@@ -34,13 +35,15 @@ function App() {
   }, [theme, systemTheme]);
 
   return (
-    <ConfigProvider theme={currentTheme} {...{ cssVar: { key: "app" } }}>
-      <AntApp>
-        <ThemedVars>
-          <AppRoutes />
-        </ThemedVars>
-      </AntApp>
-    </ConfigProvider>
+    <UserProvider>
+      <ConfigProvider theme={currentTheme} {...{ cssVar: { key: "app" } }}>
+        <AntApp>
+          <ThemedVars>
+            <AppRoutes />
+          </ThemedVars>
+        </AntApp>
+      </ConfigProvider>
+    </UserProvider>
   );
 }
 

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback  } from 'react';
 import { meAPI } from '../services/authService';
+import { useUserStore } from '../store/userStore';
 
 interface User {
     id: string;
@@ -25,15 +26,18 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
             if (!authData) {
                 console.log("Sin datos Auth guardados en localstorage");
                 setUser(null);
+                useUserStore.getState().setUser(null); // Sincronizar con store
                 return;
             }
             const parsedData = JSON.parse(authData);
             const token = parsedData.accessToken
             const response = await meAPI(token);
             setUser(response);
+            useUserStore.getState().setUser(response); // Sincronizar con store
         } catch (error) {
             console.error('Error fetching user data:', error);
             setUser(null);
+            useUserStore.getState().setUser(null); // Sincronizar con store
         }
     },[]);
 
@@ -54,4 +58,9 @@ export const useUserContext = () => {
         throw new Error('useUser  must be used within a UserProvider');
     }
     return context;
+};
+
+export const useUser = () => {
+    const { user } = useUserContext();
+    return { id: user?.id || null };
 };

--- a/client/src/pages/documents/UploadDocumentPage.tsx
+++ b/client/src/pages/documents/UploadDocumentPage.tsx
@@ -9,6 +9,7 @@ import { PdfPreviewSidebar } from "../../components/documents/PdfPreviewSidebar"
 import { DocumentDataSidebar } from "../../components/documents/DocumentDataSidebar";
 import { useDocuments } from "../../hooks/useDocuments";
 import { useChunkedDocumentUpload } from "../../hooks/useChunkedDocumentUpload";
+import { useUser } from "../../context/UserContext";
 import { useUserStore } from "../../store/userStore";
 import { useThemeStore } from "../../store/themeStore";
 import type { Document } from "../../interfaces/documentInterface";
@@ -20,6 +21,7 @@ const { useBreakpoint } = Grid;
 const UploadDocumentPage: React.FC = () => {
   const { documents, loading, downloadDocument, deleteDocument, loadDocuments } = useDocuments();
   const { processDocumentComplete } = useChunkedDocumentUpload();
+  const { id: userId } = useUser(); // Obtener id del contexto del usuario
   const user = useUserStore((s) => s.user);
   const isStudent = Boolean(user?.roles?.includes?.("estudiante"));
   const { courseId, id } = useParams<{ courseId: string; id: string }>();

--- a/client/src/services/chunkedUpload.service.ts
+++ b/client/src/services/chunkedUpload.service.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import type { CancelTokenSource } from 'axios';
-import { meAPI } from './authService';
+import { useUserStore } from '../store/userStore';
 
 export interface ChunkedUploadProgress {
   stepKey: string;
@@ -68,7 +68,11 @@ class ChunkedUploadService {
         throw new Error('Token de acceso no encontrado. Por favor, inicia sesión nuevamente.');
       }
 
-      await meAPI(token);
+      const user = useUserStore.getState().user;
+      if (!user) {
+        throw new Error('Usuario no encontrado en el contexto. Por favor, inicia sesión nuevamente.');
+      }
+
       return token;
     } catch {
       throw new Error('Sesión expirada. Por favor, inicia sesión nuevamente.');

--- a/client/src/services/documents.service.ts
+++ b/client/src/services/documents.service.ts
@@ -1,6 +1,6 @@
 import apiClient from "../api/apiClient";
 import axios from "axios";
-import { meAPI } from "./authService";
+import { useUserStore } from "../store/userStore";
 import type { 
   Document, 
   DocumentListResponse, 
@@ -40,12 +40,14 @@ const getAuthTokenAndVerifyUser = async (): Promise<{ token: string; user: UserI
       throw new Error('Token de acceso no encontrado. Por favor, inicia sesión nuevamente.');
     }
     
-    // Verificar que el token sea válido y obtener información del usuario
-    const user = await meAPI(token) as UserInfo;
+    const user = useUserStore.getState().user;
+    if (!user) {
+      throw new Error('Usuario no encontrado en el contexto. Por favor, inicia sesión nuevamente.');
+    }
     
-    return { token, user };
+    return { token, user: user as UserInfo };
   } catch (error) {
-    if (error instanceof Error && error.message.includes('Error al obtener información del usuario')) {
+    if (error instanceof Error && error.message.includes('Usuario no encontrado en el contexto')) {
       throw new Error('Sesión expirada. Por favor, inicia sesión nuevamente.');
     }
     throw new Error('Error al verificar la autenticación. Por favor, inicia sesión nuevamente.');


### PR DESCRIPTION
This pull request refactors user authentication and context management across the client application. The main improvement is the introduction of a `UserProvider` context to centralize user state and synchronize it with the existing user store. This change simplifies user data access for components and services, and replaces direct API calls for user verification with context-based checks, improving consistency and reliability.

**Context and State Management:**
* Added `UserProvider` to wrap the app in `App.tsx`, providing user context to all components and synchronizing user state between context and `useUserStore`. (`client/src/App.tsx`, `client/src/context/UserContext.tsx`) [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R10) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337R38-R46) [[3]](diffhunk://#diff-cec05280d0f5daabe7e4d90515b5bb6aead8fcc970a83dd04882d38353c91b2cR29-R40)
* Introduced `useUser` hook for simplified access to the current user's ID from context. (`client/src/context/UserContext.tsx`)

**Component Usage:**
* Updated `UploadDocumentPage` to use the new `useUser` hook for accessing the user ID, reducing direct dependency on the user store. (`client/src/pages/documents/UploadDocumentPage.tsx`) [[1]](diffhunk://#diff-25f9f7f314c11d4c91a91ceffd64ca4ff2961b4bd8626d2d4162c75538bc9cbbR12) [[2]](diffhunk://#diff-25f9f7f314c11d4c91a91ceffd64ca4ff2961b4bd8626d2d4162c75538bc9cbbR24)

**Service Layer Refactoring:**
* Changed authentication checks in `chunkedUpload.service.ts` and `documents.service.ts` to use the user context/store instead of direct API calls to `meAPI`, ensuring user presence is validated via context. (`client/src/services/chunkedUpload.service.ts`, `client/src/services/documents.service.ts`) [[1]](diffhunk://#diff-5961442352854262029362ea272b0b5d6c2229dd4ae2b0a32e4573c9f9cf2841L3-R3) [[2]](diffhunk://#diff-5961442352854262029362ea272b0b5d6c2229dd4ae2b0a32e4573c9f9cf2841L71-R75) [[3]](diffhunk://#diff-665f0b6a327269a4767a47e38815d9db8c4d93f423268e9c12f135143ab4a996L3-R3) [[4]](diffhunk://#diff-665f0b6a327269a4767a47e38815d9db8c4d93f423268e9c12f135143ab4a996L43-R50)