### PR TITLE
Fix[MD-144]:Tooltip de boton exportar en pestania datos causa desbordamiento.

### DIFF
--- a/client/src/components/documents/DocumentDataSidebar.tsx
+++ b/client/src/components/documents/DocumentDataSidebar.tsx
@@ -196,7 +196,20 @@ export const DocumentDataSidebar: React.FC<DocumentDataSidebarProps> = ({ docume
           </Button>
         </Tooltip>
 
-        <Tooltip title="Exportar como archivo de texto">
+        <Tooltip 
+          title="Exportar texto"
+          placement={isMobile ? "topLeft" : "top"}
+          getPopupContainer={(trigger) => trigger?.parentElement || window.document.body}
+          overlayStyle={{ 
+            maxWidth: isMobile ? '100px' : '140px',
+            fontSize: isMobile ? '12px' : '14px',
+            whiteSpace: 'nowrap'
+          }}
+          overlayInnerStyle={{
+            textAlign: 'center',
+            padding: isMobile ? '4px 8px' : '6px 12px'
+          }}
+        >
           <Button
             type="default"
             icon={<DownloadOutlined />}
@@ -209,17 +222,12 @@ export const DocumentDataSidebar: React.FC<DocumentDataSidebarProps> = ({ docume
         </Tooltip>
 
         <Tooltip 
-          title="Generar embeddings"
-          placement={isMobile ? "topLeft" : "top"}
+          title="Generar embeddings para búsqueda semántica"
+          placement={isMobile ? "topRight" : "top"}
           getPopupContainer={(trigger) => trigger?.parentElement || window.document.body}
           overlayStyle={{ 
-            maxWidth: isMobile ? '120px' : '180px',
-            fontSize: isMobile ? '12px' : '14px',
-            whiteSpace: 'nowrap'
-          }}
-          overlayInnerStyle={{
-            textAlign: 'center',
-            padding: isMobile ? '4px 8px' : '6px 12px'
+            maxWidth: isMobile ? '200px' : '300px',
+            fontSize: isMobile ? '12px' : '14px'
           }}
         >
           <Button

--- a/client/src/components/documents/DocumentDataSidebar.tsx
+++ b/client/src/components/documents/DocumentDataSidebar.tsx
@@ -209,12 +209,17 @@ export const DocumentDataSidebar: React.FC<DocumentDataSidebarProps> = ({ docume
         </Tooltip>
 
         <Tooltip 
-          title="Generar embeddings para búsqueda semántica"
-          placement={isMobile ? "topRight" : "top"}
+          title="Generar embeddings"
+          placement={isMobile ? "topLeft" : "top"}
           getPopupContainer={(trigger) => trigger?.parentElement || window.document.body}
           overlayStyle={{ 
-            maxWidth: isMobile ? '200px' : '300px',
-            fontSize: isMobile ? '12px' : '14px'
+            maxWidth: isMobile ? '120px' : '180px',
+            fontSize: isMobile ? '12px' : '14px',
+            whiteSpace: 'nowrap'
+          }}
+          overlayInnerStyle={{
+            textAlign: 'center',
+            padding: isMobile ? '4px 8px' : '6px 12px'
           }}
         >
           <Button


### PR DESCRIPTION
# Resumen
Se corrige el problema del tooltip del botón **"Exportar"** en la pestaña "Chunks" de Datos del Documento que se desbordaba horizontalmente en pantallas pequeñas y móviles.  
Con estos cambios, el tooltip se posiciona correctamente y mantiene un tamaño apropiado en todos los dispositivos.

# Qué se hizo
- Optimización del tooltip del botón "Exportar":
  - Se redujo el texto del tooltip de "Exportar como archivo de texto" a "Exportar texto".
  - Se cambió el `placement` en móviles a `"topLeft"` para evitar desbordamiento horizontal.
  - Se ajustaron las dimensiones: móvil `100px` y desktop `140px` (antes sin límite).
  - Se agregó `whiteSpace: 'nowrap'` para evitar saltos de línea innecesarios.
  - Se añadió `overlayInnerStyle` con padding optimizado y texto centrado.
  - Se añadió `getPopupContainer` para mejor control del posicionamiento.
- Se verificó que no afecte otros componentes del sistema.

# Por qué
- El tooltip se desbordaba horizontalmente en pantallas pequeñas, causando problemas de UX.
- El texto "Exportar como archivo de texto" era demasiado largo para el espacio disponible en vista móvil.
- Sin posicionamiento específico, el tooltip se salía del viewport en dispositivos móviles.
- Estos ajustes mejoran la accesibilidad y experiencia del usuario en todos los dispositivos.

# Cómo probar / QA
1. Iniciar la app en entorno local.
2. Navegar a la sección de **Documentos**.
3. Subir un documento y hacer clic en **"Datos"**.
4. Ir a la pestaña **"Chunks"**.
5. Verificar el tooltip del botón **"Exportar"**:
   - En **vista desktop**:
     - Hover sobre el botón → tooltip debe aparecer centrado arriba sin desbordarse.
     - El texto debe ser "Exportar texto".
   - En **vista móvil** (< 768px):
     - Tocar el botón → tooltip debe aparecer en `topLeft` sin salirse de la pantalla.
     - El ancho máximo debe ser de 100px.
6. Validar que el tooltip sea legible y no interfiera con otros elementos.
7. Probar funcionalidad: hacer clic en "Exportar" debe descargar el archivo de texto.
8. Probar en navegadores principales (Chrome, Firefox, Safari) y diferentes tamaños de pantalla.

# Archivos modificados
- `DocumentDataSidebar.tsx` — corrección del tooltip del botón "Exportar" con optimizaciones de posicionamiento y dimensiones.

# Capturas
- Antes:
<img width="1306" height="1019" alt="Captura de pantalla 2025-09-16 014656" src="https://github.com/user-attachments/assets/0a71cd7f-c34a-42b8-8712-af00819756c7" />

- Después:

<img width="958" height="846" alt="Captura de pantalla 2025-09-16 015541" src="https://github.com/user-attachments/assets/8928e9ad-7210-4729-baed-6de7ca891297" />
