### PR TITLE
fix[MD-145]: Corregir padding y contraste del modal de eliminar documento

### DIFF
--- a/client/src/components/safetyModal.tsx
+++ b/client/src/components/safetyModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback } from 'react';
-import { Modal, Button, Typography } from "antd";
+import { Modal, Button, Typography, theme as antTheme } from "antd";
 import { DeleteOutlined, ExclamationCircleOutlined, FileTextOutlined } from '@ant-design/icons';
 import type { ButtonProps } from 'antd';
+import { useThemeStore } from '../store/themeStore';
 
 const { Text } = Typography;
 
@@ -181,6 +182,11 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [deleting, setDeleting] = useState<boolean>(false);
 
+  // Tema
+  const theme = useThemeStore((state) => state.theme);
+  const isDark = theme === "dark";
+  const { token } = antTheme.useToken();
+
   // Configuración por defecto del botón
   const {
     showText = true,
@@ -277,8 +283,13 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
       {/* Modal de confirmación */}
       <Modal
         title={
-          <div style={{ display: 'flex', alignItems: 'center', color: '#d32f2f' }}>
-            <ExclamationCircleOutlined style={{ marginRight: '8px', fontSize: '20px' }} />
+          <div style={{ 
+            display: 'flex', 
+            alignItems: 'center', 
+            color: isDark ? token.colorError : '#d32f2f',
+            padding: `${token.paddingXS}px 0`
+          }}>
+            <ExclamationCircleOutlined style={{ marginRight: token.marginXS, fontSize: '20px' }} />
             <span style={{ fontWeight: '600' }}>Confirmar eliminación</span>
           </div>
         }
@@ -290,20 +301,25 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
         confirmLoading={deleting}
         centered
         width={480}
+        styles={{
+          body: {
+            padding: `${token.paddingLG}px`,
+          }
+        }}
         okButtonProps={{
           danger: true,
           size: 'large',
           style: {
-            backgroundColor: '#d32f2f',
-            borderColor: '#d32f2f',
+            backgroundColor: isDark ? token.colorErrorActive : '#d32f2f',
+            borderColor: isDark ? token.colorErrorBorder : '#d32f2f',
             fontWeight: '500'
           }
         }}
         cancelButtonProps={{
           size: 'large',
           style: {
-            borderColor: '#7A85C1',
-            color: '#3B38A0',
+            borderColor: isDark ? token.colorBorder : '#7A85C1',
+            color: isDark ? token.colorText : '#3B38A0',
             fontWeight: '500'
           }
         }}
@@ -312,8 +328,8 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
           {/* Ícono principal de eliminación */}
           <div style={{
             fontSize: '48px',
-            color: '#ff7875',
-            marginBottom: '16px',
+            color: isDark ? token.colorError : '#ff7875',
+            marginBottom: token.marginLG,
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center'
@@ -323,9 +339,9 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
 
           {/* Mensaje de confirmación */}
           <p style={{
-            marginBottom: '16px',
+            marginBottom: token.marginLG,
             fontSize: '16px',
-            color: '#262626',
+            color: isDark ? token.colorText : '#262626',
             lineHeight: '1.5'
           }}>
             {modalMessage}
@@ -333,29 +349,32 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
 
           {/* Información del recurso */}
           <div style={{
-            backgroundColor: '#fff2e8',
-            border: '1px solid #ffcc7a',
-            borderRadius: '8px',
-            padding: '16px',
-            marginTop: '16px',
+            backgroundColor: isDark ? token.colorWarningBg : '#fff2e8',
+            border: `1px solid ${isDark ? token.colorWarningBorder : '#ffcc7a'}`,
+            borderRadius: token.borderRadius,
+            padding: token.paddingLG,
+            marginTop: token.marginLG,
             textAlign: 'left'
           }}>
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '4px' }}>
-              <div style={{ color: '#d46b08', fontSize: '16px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', marginBottom: token.marginXS }}>
+              <div style={{ 
+                color: isDark ? token.colorWarning : '#d46b08', 
+                fontSize: '16px' 
+              }}>
                 {resourceInfo.icon || <FileTextOutlined />}
               </div>
               <Text strong style={{ 
-                color: '#d46b08', 
+                color: isDark ? token.colorWarning : '#d46b08', 
                 fontSize: '14px',
-                marginLeft: '8px'
+                marginLeft: token.marginXS
               }}>
                 {resourceInfo.name}
               </Text>
               {resourceInfo.type && (
                 <Text style={{ 
                   fontSize: '12px',
-                  marginLeft: '8px',
-                  color: '#fa8c16'
+                  marginLeft: token.marginXS,
+                  color: isDark ? token.colorWarningText : '#fa8c16'
                 }}>
                   ({resourceInfo.type})
                 </Text>
@@ -364,22 +383,26 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
 
             {/* Información adicional */}
             {resourceInfo.additionalInfo && (
-              <div style={{ marginTop: '8px', fontSize: '12px', color: '#d48806' }}>
+              <div style={{ 
+                marginTop: token.marginXS, 
+                fontSize: '12px', 
+                color: isDark ? token.colorWarningText : '#d48806' 
+              }}>
                 {resourceInfo.additionalInfo}
               </div>
             )}
 
             {/* Mensaje de advertencia */}
-            <div style={{ display: 'flex', alignItems: 'center', marginTop: '8px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', marginTop: token.marginXS }}>
               <ExclamationCircleOutlined style={{ 
-                color: '#fa8c16', 
-                marginRight: '6px', 
+                color: isDark ? token.colorWarning : '#fa8c16', 
+                marginRight: token.marginXXS, 
                 fontSize: '12px' 
               }} />
               <Text style={{ 
                 fontSize: '12px', 
                 fontStyle: 'italic',
-                color: '#d48806'
+                color: isDark ? token.colorWarningText : '#d48806'
               }}>
                 Esta acción no se puede deshacer
               </Text>


### PR DESCRIPTION
# Resumen
Se corrige el modal de confirmación de eliminación de documentos que presentaba problemas de **padding insuficiente** y **contraste deficiente de texto en modo oscuro**.  
Con estos cambios, el modal ahora tiene espaciado adecuado y los textos son legibles tanto en modo claro como en modo oscuro.

# Qué se hizo
- Corrección de padding:
  - Se agregó `padding: token.paddingLG` al cuerpo del modal usando la propiedad `styles.body`.
  - Se reemplazaron márgenes hardcoded (16px, 8px) con tokens de Ant Design (`token.marginLG`, `token.marginXS`, `token.marginXXS`).
- Corrección de contraste de texto:
  - Se implementó detección del tema usando `useThemeStore` y `antTheme.useToken()`.
  - Se cambió el color del título: `isDark ? token.colorError : '#d32f2f'`.
  - Se adaptó el texto principal: `isDark ? token.colorText : '#262626'`.
  - Se corrigieron colores de iconos, botones y secciones de advertencia para ambos temas.
- Mejoras de consistencia:
  - Se usó `token.borderRadius` en lugar de valores fijos.
  - Los botones del modal ahora usan `token.colorErrorActive`, `token.colorBorder` según el tema.

# Por qué
- El modal carecía de padding interno, haciendo que el contenido se viera comprimido contra los bordes.
- Los colores hardcoded (#262626, #d32f2f, #fff2e8) no se adaptaban al modo oscuro, causando texto ilegible.
- La falta de tokens del sistema de diseño creaba inconsistencias con el resto de la aplicación.
- Estos problemas afectaban la usabilidad y accesibilidad, especialmente para usuarios que prefieren modo oscuro.

# Cómo probar / QA
1. Iniciar la app en entorno local.
2. Navegar a la sección **Documentos** → tabla de documentos.
3. Verificar el modal en **modo claro**:
   - Hacer clic en el botón **"Eliminar"** de cualquier documento.
   - El modal debe tener padding interno visible (no comprimido).
   - Todos los textos deben ser legibles con buen contraste.
4. Cambiar a **modo oscuro**:
   - Repetir el proceso de eliminación.
   - Verificar que el título del modal sea visible (color de error del tema oscuro).
   - El texto principal debe ser legible (usar colorText del tema).
   - La sección de información del recurso debe tener colores de advertencia apropiados.
5. Verificar elementos específicos:
   - **Spacing**: debe haber espacio entre el contenido y los bordes del modal.
   - **Título**: debe usar color de error apropiado en ambos temas.
   - **Botones**: deben mantener estilos correctos en ambos modos.
6. Probar funcionalidad: confirmar que la eliminación sigue funcionando correctamente.

# Archivos modificados
- `safetyModal.tsx` — corrección de padding, contraste de texto y adaptación al sistema de temas de Ant Design.
- 
# Capturas
- Antes:
<img width="826" height="796" alt="Captura de pantalla 2025-09-16 023613" src="https://github.com/user-attachments/assets/d503aeb3-5b39-445a-baab-09132d6eb4c8" />

- Después:
<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/8c4da7b3-2931-4d22-b6c1-bc1c993fdc4e" />
